### PR TITLE
docs(agent): add AGENTS.md for usercss and greasemonkey

### DIFF
--- a/greasemonkey/AGENTS.md
+++ b/greasemonkey/AGENTS.md
@@ -1,0 +1,392 @@
+# Userscript Agent Guide
+
+Userscripts are JavaScript files installed into a browser via Violentmonkey (or similar). They run on page load and can manipulate the DOM, intercept events, and make cross-origin network requests.
+
+## File Structure
+
+Every script opens with a metadata block inside a `// ==UserScript== ... // ==/UserScript==` comment, followed by plain JavaScript.
+
+```js
+// ==UserScript==
+// @name        Short description - site.com
+// @namespace   ipwnponies
+// @match       https://www.example.com/path/*
+// @grant       none
+// @version     1.0.0
+// @author      ipwnponies
+// @description Longer explanation
+// ==/UserScript==
+
+// script body
+```
+
+## Metadata
+
+| Key | Purpose |
+|-----|---------|
+| `@name` | Display name in extension UI |
+| `@namespace` | Author identifier |
+| `@match` | URL pattern(s) that activate this script |
+| `@grant` | Permissions for GM APIs (`none` if not needed) |
+| `@version` | Semver string |
+| `@require` | External library loaded before the script runs |
+| `@description` | Human-readable summary |
+
+Multiple `@match` lines are allowed. Use the narrowest pattern that covers the target pages.
+
+### `@grant` and GM APIs
+
+Scripts that need cross-origin requests or persistent storage must declare the specific grant:
+
+```js
+// @grant       GM_xmlhttpRequest
+// @grant       GM.getValue
+// @grant       GM.registerMenuCommand
+// @grant       GM_openInTab
+```
+
+Use `@grant none` when you only need to touch the page DOM.
+
+### `@require` for Libraries
+
+External libraries are fetched once at install time and bundled locally:
+
+```js
+// @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
+// @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
+```
+
+Pin to a major version (`@2`, `@1`) rather than `latest` to avoid surprise breakage.
+
+## Core Patterns
+
+### sleep Helper
+
+Almost every async script defines this one-liner:
+
+```js
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+```
+
+Use it to wait for a fixed duration before querying the DOM after page load, or between retry iterations.
+
+### Polling Loop — Wait for an Element
+
+For pages that load content asynchronously, poll until the target element appears:
+
+```js
+async function main() {
+    while (!document.querySelector('.target-element')) {
+        await sleep(200);
+    }
+    // element is now present
+    doWork();
+}
+
+main();
+```
+
+This is the simplest approach when `VM.observe` is not available or the trigger is a one-time load.
+
+### `waitFor` — Polling with Timeout
+
+For time-bounded waiting with a clear error on timeout:
+
+```js
+const waitFor = async (callback, timeout = 5000, interval = 50) => {
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+        const result = callback();
+        if (result) return result;
+        await sleep(interval);
+    }
+
+    throw new Error('Timed out');
+};
+
+// Usage
+const button = await waitFor(() => document.querySelector('#submit-button'));
+button.click();
+```
+
+Use `waitFor` when you need to act as soon as the element appears rather than running at a fixed delay, and when you want explicit failure instead of a silent hang.
+
+### `VM.observe` — Mutation-Based Element Waiting
+
+The `@violentmonkey/dom` library provides `VM.observe`, which is more efficient than polling when you need to react to dynamic DOM changes:
+
+```js
+// @require https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
+
+VM.observe(document.querySelector('body'), () => {
+    const input = document.querySelector('#target-input');
+    if (input) {
+        input.addEventListener('paste', handlePaste);
+        return true; // returning true stops the observer
+    }
+    // return undefined (or nothing) to keep watching
+});
+```
+
+`VM.observe` wraps `MutationObserver` with automatic cleanup when the callback returns `true`. Use it to attach event listeners to elements that don't exist at script start time (e.g. dynamically rendered modals, SPA route changes).
+
+### `MutationObserver` — Watching for DOM Changes
+
+For more control, use a raw `MutationObserver`:
+
+```js
+const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+            if (node instanceof Element) {
+                processNode(node);
+            }
+        }
+    }
+});
+
+observer.observe(document.querySelector('body'), { subtree: true, childList: true });
+```
+
+Use `{ subtree: true, childList: true }` to catch any descendant changes. Check `node instanceof Element` to skip text nodes and comments.
+
+### Handling SPAs — Path-Based Routing
+
+In single-page applications, the page doesn't reload on navigation. Use `@match` broadly and then gate logic on the current path:
+
+```js
+// @match https://www.example.com/*
+
+const isTargetPage = () => location.pathname.startsWith('/target/');
+
+VM.observe(document.body, () => {
+    if (!isTargetPage()) return;
+
+    const el = document.querySelector('.target');
+    if (el) {
+        doWork(el);
+        return true;
+    }
+});
+```
+
+For redirects and URL manipulation, use `location.assign()` (adds history entry) or `location.replace()` (no history entry):
+
+```js
+// Redirect without adding to browser history
+document.location.replace(newUrl);
+
+// Build URLs safely with the URL API
+const redirectUrl = new URL(document.location);
+redirectUrl.searchParams.set('dt', daysEpoch);
+document.location.replace(redirectUrl);
+```
+
+## Timing Patterns
+
+### `setTimeout` Wrapper (one-shot delay)
+
+When you need to click a button after a paste event but the button state hasn't updated yet:
+
+```js
+const action = async () => {
+    await new Promise((r) => setTimeout(r, 100));
+    document.querySelector('button[type=submit]').click();
+};
+
+input.addEventListener('paste', action);
+```
+
+### `requestAnimationFrame` (wait one render cycle)
+
+When a button becomes enabled in response to an input event, `requestAnimationFrame` defers the click until after the browser has processed the event and re-rendered:
+
+```js
+input.addEventListener('paste', () => {
+    requestAnimationFrame(() => {
+        form.querySelector('button.btn-primary').click();
+    });
+});
+```
+
+Prefer `requestAnimationFrame` over `setTimeout(fn, 0)` when the goal is to wait for the next render rather than a time duration.
+
+### `setTimeout` with No Delay
+
+A bare `setTimeout(() => ...) ` (no ms argument) defers execution to after the current call stack clears, which is sometimes enough for event-driven UI updates:
+
+```js
+const clickButton = (selector) => () => {
+    setTimeout(() => {
+        document.querySelector(selector)?.click();
+    });
+};
+```
+
+## Event Interception Patterns
+
+### Bypassing Paste Blockers
+
+Sites that call `e.preventDefault()` on paste events can be bypassed by registering a listener in the **capture phase** before their listener runs:
+
+```js
+field.addEventListener(
+    'keydown',
+    (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+            e.stopImmediatePropagation(); // prevents all other keydown handlers
+        }
+    },
+    { capture: true }, // runs before bubble-phase listeners
+);
+```
+
+`stopImmediatePropagation` blocks all subsequent handlers for the same event on the same element. `stopPropagation` only blocks bubbling to parent elements.
+
+### Bypassing `selectstart` Blockers
+
+Sites that block text selection via `selectstart`:
+
+```js
+document.body.addEventListener('selectstart', (e) => e.stopPropagation(), { capture: true });
+```
+
+### Auto-Submit on Paste
+
+Common pattern for 2FA and login forms — click the submit button automatically when a code is pasted:
+
+```js
+VM.observe(document.body, () => {
+    const input = document.querySelector('#otp-input');
+    if (input) {
+        for (const event of ['paste', 'change']) {
+            input.addEventListener(event, () => {
+                requestAnimationFrame(() => {
+                    document.querySelector('#submit-button').click();
+                });
+            });
+        }
+        return true;
+    }
+});
+```
+
+Listen to both `paste` (manual paste) and `change` (password manager fill) to cover both entry methods.
+
+## Keyboard Shortcuts
+
+Use `@violentmonkey/shortcut` for keyboard shortcut registration:
+
+```js
+// @require https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
+
+const { register } = VM.shortcut;
+
+register('ctrl-k', () => {
+    // action
+});
+```
+
+Standard modifier names: `ctrl`, `alt`, `shift`, `meta`. Key names are lowercase (`k`, `enter`, `escape`).
+
+## Cross-Origin Requests
+
+Scripts needing requests to external domains must use `GM_xmlhttpRequest` (not `fetch`), which bypasses CORS:
+
+```js
+// @grant GM_xmlhttpRequest
+
+GM_xmlhttpRequest({
+    method: 'POST',
+    url: 'https://api.example.com/graphql',
+    data: queryString,
+    headers: { 'Content-Type': 'application/graphql', Authorization: `Bearer ${apiKey}` },
+    onload: (response) => {
+        const data = JSON.parse(response.response);
+        // use data
+    },
+});
+```
+
+## Persistent Storage
+
+Use `GM.getValue` / `GM.setValue` for user configuration that survives page reloads:
+
+```js
+// @grant GM.getValue
+
+const apiKey = GM_getValue('apiKey');
+if (!apiKey) {
+    alert('Set "apiKey" in script storage before using this script.');
+    throw new Error('apiKey not set');
+}
+```
+
+Users set values through the extension's storage editor.
+
+## DOM Manipulation Utilities
+
+### XPath for Complex Queries
+
+When CSS selectors can't target an element by text content, use XPath:
+
+```js
+const findByText = (text) => document.evaluate(
+    `//span[contains(text(),"${text}")]`,
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null,
+).singleNodeValue;
+
+const removeOption = findByText('Remove from');
+removeOption?.click();
+```
+
+### Idempotency Guard
+
+Prevent a script from adding duplicate UI elements when it re-runs (e.g. after a SPA navigation):
+
+```js
+const addButton = (node) => {
+    if (node.nextElementSibling?.classList.contains('my-script-marker')) return;
+
+    const btn = document.createElement('button');
+    btn.classList.add('my-script-marker');
+    node.after(btn);
+};
+```
+
+Add a marker class to injected elements and check for it before inserting again.
+
+### Injecting External CSS
+
+When the script needs to bring its own styles:
+
+```js
+const link = document.createElement('link');
+link.href = 'https://cdn.example.com/styles.css';
+link.rel = 'stylesheet';
+link.type = 'text/css';
+document.head.appendChild(link);
+```
+
+## Naming Convention
+
+Files are named `<domain>.<purpose>.user.js`. The `@name` should follow the pattern `<Short purpose> - <domain>`.
+
+## zone.js Workaround
+
+Angular apps (and some others) wrap `addEventListener` using zone.js. To bypass the wrapper and register a native listener:
+
+```js
+input.addEventListener.__zone_symbol__OriginalDelegate.call(
+    input,
+    'paste',
+    handler,
+    false,
+);
+```
+
+Only use this when the zone.js wrapper is actively breaking event handling (e.g. preventing auto-submit from working).

--- a/greasemonkey/AGENTS.md
+++ b/greasemonkey/AGENTS.md
@@ -37,13 +37,38 @@ Multiple `@match` lines are allowed. Use the narrowest pattern that covers the t
 
 ### `@grant` and GM APIs
 
-Scripts that need cross-origin requests or persistent storage must declare the specific grant:
+Two API styles exist:
+
+- **`GM.`** (modern) — Promise-based. Declare as `@grant GM.methodName`.
+- **`GM_`** (legacy) — Synchronous/callback-based. Declare as `@grant GM_methodName`.
+
+The grant string must match the API style used — they are separate APIs, not aliases.
+
+For fire-and-forget operations where you don't need the result (opening a tab, showing a notification, writing to clipboard, setting or deleting a stored value), the returned promise can be ignored:
 
 ```js
-// @grant       GM_xmlhttpRequest
-// @grant       GM.getValue
-// @grant       GM.registerMenuCommand
-// @grant       GM_openInTab
+// No await needed — fire and forget
+GM.setValue('key', value);
+GM.deleteValue('key');
+GM_openInTab('https://example.com', true);
+GM.notification({ text: 'Done!' });
+GM.setClipboard('text to copy');
+```
+
+When you need the result, `await` it:
+
+```js
+// @grant GM.getValue
+
+const apiKey = await GM.getValue('apiKey');
+```
+
+Or use the legacy synchronous API to avoid async:
+
+```js
+// @grant GM_getValue
+
+const apiKey = GM_getValue('apiKey');
 ```
 
 Use `@grant none` when you only need to touch the page DOM.
@@ -77,11 +102,11 @@ For pages that load content asynchronously, poll until the target element appear
 
 ```js
 async function main() {
-    while (!document.querySelector('.target-element')) {
-        await sleep(200);
-    }
-    // element is now present
-    doWork();
+  while (!document.querySelector('.target-element')) {
+    await sleep(200);
+  }
+  // element is now present
+  doWork();
 }
 
 main();
@@ -95,15 +120,15 @@ For time-bounded waiting with a clear error on timeout:
 
 ```js
 const waitFor = async (callback, timeout = 5000, interval = 50) => {
-    const deadline = Date.now() + timeout;
+  const deadline = Date.now() + timeout;
 
-    while (Date.now() < deadline) {
-        const result = callback();
-        if (result) return result;
-        await sleep(interval);
-    }
+  while (Date.now() < deadline) {
+    const result = callback();
+    if (result) return result;
+    await sleep(interval);
+  }
 
-    throw new Error('Timed out');
+  throw new Error('Timed out');
 };
 
 // Usage
@@ -121,12 +146,12 @@ The `@violentmonkey/dom` library provides `VM.observe`, which is more efficient 
 // @require https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 
 VM.observe(document.querySelector('body'), () => {
-    const input = document.querySelector('#target-input');
-    if (input) {
-        input.addEventListener('paste', handlePaste);
-        return true; // returning true stops the observer
-    }
-    // return undefined (or nothing) to keep watching
+  const input = document.querySelector('#target-input');
+  if (input) {
+    input.addEventListener('paste', handlePaste);
+    return true; // returning true stops the observer
+  }
+  // return undefined (or nothing) to keep watching
 });
 ```
 
@@ -138,13 +163,13 @@ For more control, use a raw `MutationObserver`:
 
 ```js
 const observer = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-        for (const node of mutation.addedNodes) {
-            if (node instanceof Element) {
-                processNode(node);
-            }
-        }
+  for (const mutation of mutations) {
+    for (const node of mutation.addedNodes) {
+      if (node instanceof Element) {
+        processNode(node);
+      }
     }
+  }
 });
 
 observer.observe(document.querySelector('body'), { subtree: true, childList: true });
@@ -162,15 +187,17 @@ In single-page applications, the page doesn't reload on navigation. Use `@match`
 const isTargetPage = () => location.pathname.startsWith('/target/');
 
 VM.observe(document.body, () => {
-    if (!isTargetPage()) return;
+  if (!isTargetPage()) return;
 
-    const el = document.querySelector('.target');
-    if (el) {
-        doWork(el);
-        return true;
-    }
+  const el = document.querySelector('.target');
+  if (el) {
+    doWork(el);
+    return true;
+  }
 });
 ```
+
+**Important for SPAs:** `return true` stops the observer permanently. In a normal page load, the script runs fresh on each navigation, so stopping after success is fine. In a SPA, the script only loads once for the whole session — subsequent route changes won't reload it. If you need to re-run setup on each navigation to a target page (rather than just once), do not `return true`; instead keep observing and re-check the path on each mutation.
 
 For redirects and URL manipulation, use `location.assign()` (adds history entry) or `location.replace()` (no history entry):
 
@@ -192,8 +219,8 @@ When you need to click a button after a paste event but the button state hasn't 
 
 ```js
 const action = async () => {
-    await new Promise((r) => setTimeout(r, 100));
-    document.querySelector('button[type=submit]').click();
+  await new Promise((r) => setTimeout(r, 100));
+  document.querySelector('button[type=submit]').click();
 };
 
 input.addEventListener('paste', action);
@@ -205,9 +232,9 @@ When a button becomes enabled in response to an input event, `requestAnimationFr
 
 ```js
 input.addEventListener('paste', () => {
-    requestAnimationFrame(() => {
-        form.querySelector('button.btn-primary').click();
-    });
+  requestAnimationFrame(() => {
+    form.querySelector('button.btn-primary').click();
+  });
 });
 ```
 
@@ -215,13 +242,13 @@ Prefer `requestAnimationFrame` over `setTimeout(fn, 0)` when the goal is to wait
 
 ### `setTimeout` with No Delay
 
-A bare `setTimeout(() => ...) ` (no ms argument) defers execution to after the current call stack clears, which is sometimes enough for event-driven UI updates:
+A bare `setTimeout(() => ...)` (no ms argument) defers execution to after the current call stack clears, which is sometimes enough for event-driven UI updates:
 
 ```js
 const clickButton = (selector) => () => {
-    setTimeout(() => {
-        document.querySelector(selector)?.click();
-    });
+  setTimeout(() => {
+    document.querySelector(selector)?.click();
+  });
 };
 ```
 
@@ -233,13 +260,13 @@ Sites that call `e.preventDefault()` on paste events can be bypassed by register
 
 ```js
 field.addEventListener(
-    'keydown',
-    (e) => {
-        if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
-            e.stopImmediatePropagation(); // prevents all other keydown handlers
-        }
-    },
-    { capture: true }, // runs before bubble-phase listeners
+  'keydown',
+  (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+      e.stopImmediatePropagation(); // prevents all other keydown handlers
+    }
+  },
+  { capture: true }, // runs before bubble-phase listeners
 );
 ```
 
@@ -259,17 +286,17 @@ Common pattern for 2FA and login forms — click the submit button automatically
 
 ```js
 VM.observe(document.body, () => {
-    const input = document.querySelector('#otp-input');
-    if (input) {
-        for (const event of ['paste', 'change']) {
-            input.addEventListener(event, () => {
-                requestAnimationFrame(() => {
-                    document.querySelector('#submit-button').click();
-                });
-            });
-        }
-        return true;
+  const input = document.querySelector('#otp-input');
+  if (input) {
+    for (const event of ['paste', 'change']) {
+      input.addEventListener(event, () => {
+        requestAnimationFrame(() => {
+          document.querySelector('#submit-button').click();
+        });
+      });
     }
+    return true;
+  }
 });
 ```
 
@@ -285,7 +312,7 @@ Use `@violentmonkey/shortcut` for keyboard shortcut registration:
 const { register } = VM.shortcut;
 
 register('ctrl-k', () => {
-    // action
+  // action
 });
 ```
 
@@ -299,29 +326,39 @@ Scripts needing requests to external domains must use `GM_xmlhttpRequest` (not `
 // @grant GM_xmlhttpRequest
 
 GM_xmlhttpRequest({
-    method: 'POST',
-    url: 'https://api.example.com/graphql',
-    data: queryString,
-    headers: { 'Content-Type': 'application/graphql', Authorization: `Bearer ${apiKey}` },
-    onload: (response) => {
-        const data = JSON.parse(response.response);
-        // use data
-    },
+  method: 'POST',
+  url: 'https://api.example.com/graphql',
+  data: queryString,
+  headers: { 'Content-Type': 'application/graphql', Authorization: `Bearer ${apiKey}` },
+  onload: (response) => {
+    const data = JSON.parse(response.response);
+    // use data
+  },
 });
 ```
 
 ## Persistent Storage
 
-Use `GM.getValue` / `GM.setValue` for user configuration that survives page reloads:
+Use `GM.getValue` / `GM.setValue` for user configuration that survives page reloads.
+
+`GM.getValue` returns a Promise — `await` it when you need the value before continuing:
 
 ```js
 // @grant GM.getValue
 
-const apiKey = GM_getValue('apiKey');
+const apiKey = await GM.getValue('apiKey');
 if (!apiKey) {
-    alert('Set "apiKey" in script storage before using this script.');
-    throw new Error('apiKey not set');
+  alert('Set "apiKey" in script storage before using this script.');
+  throw new Error('apiKey not set');
 }
+```
+
+`GM.setValue` and `GM.deleteValue` are fire-and-forget — no need to `await`:
+
+```js
+// @grant GM.setValue
+
+GM.setValue('lastRun', Date.now());
 ```
 
 Users set values through the extension's storage editor.
@@ -334,11 +371,11 @@ When CSS selectors can't target an element by text content, use XPath:
 
 ```js
 const findByText = (text) => document.evaluate(
-    `//span[contains(text(),"${text}")]`,
-    document,
-    null,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-    null,
+  `//span[contains(text(),"${text}")]`,
+  document,
+  null,
+  XPathResult.FIRST_ORDERED_NODE_TYPE,
+  null,
 ).singleNodeValue;
 
 const removeOption = findByText('Remove from');
@@ -351,11 +388,11 @@ Prevent a script from adding duplicate UI elements when it re-runs (e.g. after a
 
 ```js
 const addButton = (node) => {
-    if (node.nextElementSibling?.classList.contains('my-script-marker')) return;
+  if (node.nextElementSibling?.classList.contains('my-script-marker')) return;
 
-    const btn = document.createElement('button');
-    btn.classList.add('my-script-marker');
-    node.after(btn);
+  const btn = document.createElement('button');
+  btn.classList.add('my-script-marker');
+  node.after(btn);
 };
 ```
 
@@ -383,10 +420,10 @@ Angular apps (and some others) wrap `addEventListener` using zone.js. To bypass 
 
 ```js
 input.addEventListener.__zone_symbol__OriginalDelegate.call(
-    input,
-    'paste',
-    handler,
-    false,
+  input,
+  'paste',
+  handler,
+  false,
 );
 ```
 

--- a/greasemonkey/AGENTS.md
+++ b/greasemonkey/AGENTS.md
@@ -13,7 +13,6 @@ Every script opens with a metadata block inside a `// ==UserScript== ... // ==/U
 // @match       https://www.example.com/path/*
 // @grant       none
 // @version     1.0.0
-// @author      ipwnponies
 // @description Longer explanation
 // ==/UserScript==
 
@@ -25,12 +24,14 @@ Every script opens with a metadata block inside a `// ==UserScript== ... // ==/U
 | Key | Purpose |
 |-----|---------|
 | `@name` | Display name in extension UI |
-| `@namespace` | Author identifier |
+| `@namespace` | Author identifier — forms the unique script identity together with `@name` |
 | `@match` | URL pattern(s) that activate this script |
 | `@grant` | Permissions for GM APIs (`none` if not needed) |
 | `@version` | Semver string |
 | `@require` | External library loaded before the script runs |
 | `@description` | Human-readable summary |
+
+The extension uses `@namespace` + `@name` as the unique script identity. When installing an update, it matches on this pair to replace the existing script rather than install a duplicate. Do not use `@author` — it is purely informational with no technical role, and `@namespace` already encodes authorship.
 
 Multiple `@match` lines are allowed. Use the narrowest pattern that covers the target pages.
 

--- a/greasemonkey/AGENTS.md
+++ b/greasemonkey/AGENTS.md
@@ -37,41 +37,56 @@ Multiple `@match` lines are allowed. Use the narrowest pattern that covers the t
 
 ### `@grant` and GM APIs
 
-Two API styles exist:
+Two API styles exist — the grant string must match the API used, they are not aliases:
 
 - **`GM.`** (modern) — Promise-based. Declare as `@grant GM.methodName`.
-- **`GM_`** (legacy) — Synchronous/callback-based. Declare as `@grant GM_methodName`.
+- **`GM_`** (legacy) — Synchronous or callback-based. Declare as `@grant GM_methodName`.
 
-The grant string must match the API style used — they are separate APIs, not aliases.
+Use `@grant none` when you only need to touch the page DOM.
 
-For fire-and-forget operations where you don't need the result (opening a tab, showing a notification, writing to clipboard, setting or deleting a stored value), the returned promise can be ignored:
+#### Fire-and-forget
 
-```js
-// No await needed — fire and forget
-GM.setValue('key', value);
-GM.deleteValue('key');
-GM_openInTab('https://example.com', true);
-GM.notification({ text: 'Done!' });
-GM.setClipboard('text to copy');
-```
-
-When you need the result, `await` it:
+These return Promises but the result is never needed — call without `await`:
 
 ```js
-// @grant GM.getValue
-
-const apiKey = await GM.getValue('apiKey');
+GM.setValue('key', value);      // write to storage
+GM.deleteValue('key');          // delete from storage
+GM.openInTab('https://...');    // open a new tab
+GM.notification({ text: '!' }); // browser notification
+GM.setClipboard('text');        // write to clipboard
+GM.addStyle('body { ... }');    // inject CSS
 ```
 
-Or use the legacy synchronous API to avoid async:
+#### Synchronous in practice
+
+Violentmonkey pre-loads all stored values before the script runs, so the legacy read APIs are synchronous (in-memory reads, no I/O):
 
 ```js
 // @grant GM_getValue
+// @grant GM_listValues
 
-const apiKey = GM_getValue('apiKey');
+const apiKey = GM_getValue('apiKey'); // synchronous, no await needed
+const keys = GM_listValues();         // synchronous
 ```
 
-Use `@grant none` when you only need to touch the page DOM.
+`GM.info` is a plain object property, not a function — just read it directly: `GM.info.script.version`.
+
+Prefer the legacy synchronous forms when reading values at script startup to avoid unnecessary async ceremony.
+
+#### Await when you need the result
+
+```js
+// @grant GM.getValue
+const value = await GM.getValue('key');
+
+// @grant GM.listValues
+const keys = await GM.listValues();
+
+// @grant GM.getResourceURL
+const url = await GM.getResourceURL('icon');
+```
+
+`GM.registerMenuCommand` returns a command ID — capture it if you need to call `GM.unregisterMenuCommand` later.
 
 ### `@require` for Libraries
 
@@ -85,6 +100,44 @@ External libraries are fetched once at install time and bundled locally:
 Pin to a major version (`@2`, `@1`) rather than `latest` to avoid surprise breakage.
 
 ## Core Patterns
+
+### Eager Promises — Deferred Await
+
+Start an async operation immediately at script load, but don't `await` it until the result is actually needed. This lets I/O run in parallel with synchronous setup work rather than blocking it.
+
+```js
+// @grant GM.getValue
+// @grant GM_xmlhttpRequest
+
+// Kick off storage read and network request immediately — neither blocks execution
+const configPromise = GM.getValue('config');
+const dataPromise = new Promise((resolve, reject) => {
+  GM_xmlhttpRequest({
+    method: 'GET',
+    url: 'https://api.example.com/data',
+    onload: (r) => resolve(JSON.parse(r.response)),
+    onerror: reject,
+  });
+});
+
+// Synchronous setup runs while the above are in-flight
+VM.observe(document.body, () => { ... });
+setupEventListeners();
+
+// Only block when the values are actually needed
+async function onButtonClick() {
+  const config = await configPromise; // likely already resolved by now
+  const data = await dataPromise;
+  render(config, data);
+}
+```
+
+The key insight: `await` defers a single call site, not when the Promise starts. Awaiting a Promise that already resolved returns immediately. Kicking off work early makes the eventual `await` cheap.
+
+This is most useful when:
+- Reading stored config (`GM.getValue`) at the top of a script that also does DOM setup
+- Making a background API call whose result is only needed on user interaction
+- Fetching multiple independent resources — start them all, await each only when needed
 
 ### sleep Helper
 
@@ -320,7 +373,7 @@ Standard modifier names: `ctrl`, `alt`, `shift`, `meta`. Key names are lowercase
 
 ## Cross-Origin Requests
 
-Scripts needing requests to external domains must use `GM_xmlhttpRequest` (not `fetch`), which bypasses CORS:
+Scripts needing requests to external domains must use `GM_xmlhttpRequest` (not `fetch`), which bypasses CORS. The legacy form takes an `onload` callback:
 
 ```js
 // @grant GM_xmlhttpRequest
@@ -337,31 +390,59 @@ GM_xmlhttpRequest({
 });
 ```
 
-## Persistent Storage
-
-Use `GM.getValue` / `GM.setValue` for user configuration that survives page reloads.
-
-`GM.getValue` returns a Promise — `await` it when you need the value before continuing:
+Wrap it in a Promise to use `await` and enable the eager-promise pattern:
 
 ```js
-// @grant GM.getValue
+const fetchData = (url) => new Promise((resolve, reject) => {
+  GM_xmlhttpRequest({
+    method: 'GET',
+    url,
+    onload: (r) => resolve(JSON.parse(r.response)),
+    onerror: reject,
+  });
+});
 
-const apiKey = await GM.getValue('apiKey');
+// Start early, await when needed
+const dataPromise = fetchData('https://api.example.com/data');
+// ... other setup ...
+const data = await dataPromise;
+```
+
+## Persistent Storage
+
+Use the GM storage API for user configuration that survives page reloads. Users set values through the extension's storage editor.
+
+**Reading:** prefer the legacy synchronous form at script startup — Violentmonkey pre-loads storage, so `GM_getValue` is an in-memory read with no async overhead:
+
+```js
+// @grant GM_getValue
+
+const apiKey = GM_getValue('apiKey');
 if (!apiKey) {
   alert('Set "apiKey" in script storage before using this script.');
   throw new Error('apiKey not set');
 }
 ```
 
-`GM.setValue` and `GM.deleteValue` are fire-and-forget — no need to `await`:
+If using the modern Promise form, kick it off early and await later (see Eager Promises pattern):
+
+```js
+// @grant GM.getValue
+
+const apiKeyPromise = GM.getValue('apiKey'); // starts immediately
+// ... setup work ...
+const apiKey = await apiKeyPromise;
+```
+
+**Writing:** fire-and-forget, no `await` needed:
 
 ```js
 // @grant GM.setValue
+// @grant GM.deleteValue
 
 GM.setValue('lastRun', Date.now());
+GM.deleteValue('staleKey');
 ```
-
-Users set values through the extension's storage editor.
 
 ## DOM Manipulation Utilities
 

--- a/greasemonkey/arstechnica.comment-shortcut.user.js
+++ b/greasemonkey/arstechnica.comment-shortcut.user.js
@@ -4,7 +4,6 @@
 // @match       https://arstechnica.com/*
 // @grant       none
 // @version     2.0
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add shortcut to go to comment section
 // ==/UserScript==

--- a/greasemonkey/carta.autosubmit-2fa.user.js
+++ b/greasemonkey/carta.autosubmit-2fa.user.js
@@ -5,7 +5,6 @@
 // @match       https://login.app.carta.com/credentials/2fa/verify-challenge/
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when login or 2fa code is pasted or inserted by password manager
 // ==/UserScript==

--- a/greasemonkey/cenlar.always-agree-checkbox.user.js
+++ b/greasemonkey/cenlar.always-agree-checkbox.user.js
@@ -1,6 +1,5 @@
 // ==UserScript==
 // @name        Always check agree box - loanadministration.com
-// @author      ipwnponies
 // @version     1.1.1
 // @match       https://www.loanadministration.com/*
 // @grant       none

--- a/greasemonkey/duckduckgo.just-get-to-the-page-already.user.js
+++ b/greasemonkey/duckduckgo.just-get-to-the-page-already.user.js
@@ -4,7 +4,6 @@
 // @match       https://duckduckgo.com/*
 // @grant       none
 // @version     1.2
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when using AI chat. It always prompts because no prior cookies when using clean containers
 // ==/UserScript==

--- a/greasemonkey/fidelity.autosubmit-2fa.user.js
+++ b/greasemonkey/fidelity.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://digital.fidelity.com/prgw/digital/login/full-page*
 // @grant       none
 // @version     2.2
-// @author      ipwnponies
 // @require https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when login or 2fa code is pasted or inserted by password manager
 // ==/UserScript==

--- a/greasemonkey/firsttech.autosubmit-2fa.user.js
+++ b/greasemonkey/firsttech.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://banking.firsttechfed.com/Authentication
 // @grant       none
 // @version     1.1
-// @author      ipwnponies
 // @require https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when 2fa code is pasted
 // ==/UserScript==

--- a/greasemonkey/freetaxusa.autosubmit-2fa.user.js
+++ b/greasemonkey/freetaxusa.autosubmit-2fa.user.js
@@ -1,6 +1,5 @@
 // ==UserScript==
 // @name        Auto submit upon paste - freetaxusa.com
-// @author      ipwnponies
 // @match       https://auth.freetaxusa.com/
 // @grant       none
 // @version     1.0

--- a/greasemonkey/github.approve-shortcut.user.js
+++ b/greasemonkey/github.approve-shortcut.user.js
@@ -5,7 +5,6 @@
 // @match       https://github.com/*
 // @grant       none
 // @version     1.0.1
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add shortcut to ship it!
 // ==/UserScript==

--- a/greasemonkey/github.edit-shortcut.user.js
+++ b/greasemonkey/github.edit-shortcut.user.js
@@ -5,7 +5,6 @@
 // @match       https://github.com/*
 // @grant       none
 // @version     1.0.1
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add shortcut to edit the pull request description
 // ==/UserScript==

--- a/greasemonkey/github.open-links-new-tab.user.js
+++ b/greasemonkey/github.open-links-new-tab.user.js
@@ -5,7 +5,6 @@
 // @match       https://github.com/*
 // @grant       none
 // @version     1.2.1
-// @author      ipwnponies
 // @description When you're reviewing a github pull request, the last thing you want is to navigate away from that tab.
 // ==/UserScript==
 const mutationCallback = () => {

--- a/greasemonkey/gmail.open-tadpole-images.user.js
+++ b/greasemonkey/gmail.open-tadpole-images.user.js
@@ -4,7 +4,6 @@
 // @match       https://mail.google.com/mail/u/*
 // @grant       none
 // @version     1.1
-// @author      ipwnponies
 // @require https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Open all images in a new tab
 // ==/UserScript==

--- a/greasemonkey/google-photos.keybinding-options.user.js
+++ b/greasemonkey/google-photos.keybinding-options.user.js
@@ -5,7 +5,6 @@
 // @match       https://photos.google.com/album/*
 // @grant       none
 // @version     1.0.2
-// @author      ipwnponies
 // @require https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Keybinding to access the options menu in Google Photos
 // ==/UserScript==

--- a/greasemonkey/guardian.autosubmit-2fa.user.js
+++ b/greasemonkey/guardian.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://login.guardianlife.com/oauth2/default/v1/authorize*
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when login or 2fa code is pasted or inserted by password manager
 // ==/UserScript==

--- a/greasemonkey/leetcode-filtering.user.js
+++ b/greasemonkey/leetcode-filtering.user.js
@@ -4,7 +4,6 @@
 // @match       https://leetcode.com/tag/*
 // @grant       none
 // @version     1.0.0
-// @author      ipwnponies
 // @description When viewing problems by tags, there are no filters.
 //              Why? Who knows. But it's a trivial problem solved with some javscripts.
 // ==/UserScript==

--- a/greasemonkey/navia.autosubmit-2fa.user.js
+++ b/greasemonkey/navia.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://app.naviabenefits.com/*
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when login or 2fa code is pasted or inserted by password manager
 // ==/UserScript==

--- a/greasemonkey/paypal.autosubmit-2fa.user.js
+++ b/greasemonkey/paypal.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://www.paypal.com/authflow/twofactor/*
 // @grant       none
 // @version     1.1
-// @author      ipwnponies
 // @description Clicky button when 2fa code is pasted
 // ==/UserScript==
 

--- a/greasemonkey/rubios.let-me-copy-paste.user.js
+++ b/greasemonkey/rubios.let-me-copy-paste.user.js
@@ -4,7 +4,6 @@
 // @match       https://tellrubios.com/Finish.aspx
 // @grant       none
 // @version     1.1
-// @author      ipwnponies
 // @description For some unknown reason, they have prevented selection. Unfuck their shit.
 // ==/UserScript==
 

--- a/greasemonkey/scholarshare529.autosubmit-paste.user.js
+++ b/greasemonkey/scholarshare529.autosubmit-paste.user.js
@@ -4,7 +4,6 @@
 // @match       https://www.cascholarshare529.com/cadtpl/auth/ll.cs
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @description Clicky button when username is pasted or inserted by password manager. Only needed for username input
 // page, the password input page is auto submit-able
 // ==/UserScript==

--- a/greasemonkey/sdge.let-me-copy-paste.user.js
+++ b/greasemonkey/sdge.let-me-copy-paste.user.js
@@ -5,7 +5,6 @@
 // @match       https://myenergycenter.com/portal/PreLogin/Validate
 // @grant       none
 // @version     1.0.1
-// @author      ipwnponies
 // @description Why the ass would you not allow paste of the 2FA code. Unfuck their shit.
 // ==/UserScript==
 

--- a/greasemonkey/sdttc.let-me-paste.user.js
+++ b/greasemonkey/sdttc.let-me-paste.user.js
@@ -4,7 +4,6 @@
 // @match       https://wps.sdttc.com/webpayments/CoSDTreasurer2/*
 // @grant       none
 // @version     1.0.2
-// @author      ipwnponies
 // @description Why the ass would you not allow paste of bank account info. Unfuck their shit.
 // ==/UserScript==
 

--- a/greasemonkey/tadpoles.redirect-to-image-src.user.js
+++ b/greasemonkey/tadpoles.redirect-to-image-src.user.js
@@ -4,7 +4,6 @@
 // @match       https://www.tadpoles.com/m/p/*
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @description Direct redirect to image source. This makes it trivial to save the image
 // ==/UserScript==
 

--- a/greasemonkey/trakt.search-rotten-tomatoes.user.js
+++ b/greasemonkey/trakt.search-rotten-tomatoes.user.js
@@ -5,7 +5,6 @@
 // @grant       GM_registerMenuCommand
 // @version     1.1
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
-// @author      ipwnponies
 // @description Add a link to search movie on rotten tomatoes
 // ==/UserScript==
 

--- a/greasemonkey/usbank.autosubmit-2fa.user.js
+++ b/greasemonkey/usbank.autosubmit-2fa.user.js
@@ -4,7 +4,6 @@
 // @match       https://onlinebanking.usbank.com/auth/login/*
 // @grant       none
 // @version     1.0.1
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
 // @description Clicky button when login or 2fa code is pasted or inserted by password manager
 // ==/UserScript==

--- a/greasemonkey/youtube.clear-playlist.user.js
+++ b/greasemonkey/youtube.clear-playlist.user.js
@@ -6,7 +6,6 @@
 // @grant       GM.registerMenuCommand
 // @grant       GM.getValue
 // @version     1.5.3
-// @author      ipwnponies
 // @description Add a button to clear all items in a playlist.
 // ==/UserScript==
 

--- a/greasemonkey/youtube.show-transcript-hotkey.user.js
+++ b/greasemonkey/youtube.show-transcript-hotkey.user.js
@@ -4,7 +4,6 @@
 // @match       https://www.youtube.com/watch*
 // @grant       none
 // @version     1.0
-// @author      ipwnponies
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add hotkey to click the show transcript button.
 // ==/UserScript==

--- a/usercss/AGENTS.md
+++ b/usercss/AGENTS.md
@@ -1,0 +1,240 @@
+# UserCSS Agent Guide
+
+UserCSS files are custom stylesheets installed into a browser via a style manager extension (e.g. Stylus). Each file targets one or more specific sites and overrides their default presentation.
+
+## File Structure
+
+Every file starts with a metadata block, then one or more `@-moz-document` rules that scope the CSS to specific URLs.
+
+```css
+/* ==UserStyle==
+@name           example.com
+@namespace      ipwnponies
+@version        1.0.0
+@license        MIT
+@description    What this does
+
+@var range font-size "Font size" [1.2, 0.6, 2.0, 0.2, "em"]
+==/UserStyle== */
+
+@-moz-document domain("example.com") {
+    /* rules here */
+}
+```
+
+## Metadata
+
+| Key | Purpose |
+|-----|---------|
+| `@name` | Display name in the extension UI |
+| `@namespace` | Author identifier, prevents name collisions |
+| `@version` | Semver string |
+| `@license` | SPDX license identifier |
+| `@description` | Short summary |
+| `@var` | Declares a user-configurable variable (see below) |
+
+### `@var` Declarations
+
+Variables let users tune values through the extension UI without editing raw CSS. The extension injects them as CSS custom properties (e.g. `--font-size`) that you reference with `var()`.
+
+**Range slider** — numeric value with min/max/step, optional unit suffix:
+```
+@var range font-size "Font size" [default, min, max, step, "unit"]
+@var range font-size "Font size" [1.2, 0.6, 2.0, 0.2, "em"]
+@var range line-height "Line spacing" [1.5, 1.0, 2.0, 0.1]
+```
+
+**Select dropdown** — named options, mark default with `*`:
+```
+@var select font-weight "Font weight" {
+  "Light*": "lighter",
+  "Normal": "normal",
+  "Bold": "bold",
+}
+```
+
+Using the variable in CSS:
+```css
+p {
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+}
+```
+
+## URL Scoping with `@-moz-document`
+
+Despite the `-moz-` prefix, this is the standard way to scope userstyles. Three forms are used:
+
+```css
+/* All pages on a domain */
+@-moz-document domain("example.com") { }
+
+/* Pages under a path prefix */
+@-moz-document url-prefix("https://example.com/app/") { }
+
+/* Regular expression match */
+@-moz-document regexp("https://gamefaqs.gamespot.com(/[a-z0-9-/]+){2}/faqs/\\d+") { }
+```
+
+Use the narrowest scope possible. `url-prefix` is preferred over `domain` when the styles only apply to a subsection of a site.
+
+## Common Patterns
+
+### `!important` Is the Primary Tool
+
+Site CSS ships with high-specificity selectors. Userstyles almost always lose specificity battles, so `!important` is the normal override mechanism — not an antipattern here.
+
+```css
+/* Override inline styles or high-specificity site rules */
+textarea {
+    min-height: var(--textbox-height) !important;
+}
+
+pre {
+    font: lighter var(--font-size)/var(--line-height) monospace !important;
+}
+```
+
+Use `!important` freely when fighting site styles. Leave it off only when your selector already wins naturally (e.g. when overriding a low-specificity reset).
+
+### Hiding Unwanted Elements
+
+```css
+/* Hide by ID or class */
+#WikiaRailWrapper,
+#WikiaFooter {
+    display: none;
+}
+
+/* Hide by attribute value — useful for inline event handlers */
+div[oncontextmenu="return false;"] {
+    display: none;
+}
+
+/* Hide ads and autoplay widgets */
+.product-widget,
+.fexy-modal__outer-wrap {
+    display: none;
+}
+```
+
+Hiding by `display: none` is the blunt but reliable approach. Attribute selectors let you target elements that have no stable class or ID.
+
+### Layout Overrides
+
+Overriding grid and flex layouts to remove sidebars or reorder content:
+
+```css
+/* Remove right rail from a two-column grid */
+.article-two-column-right-rail {
+    grid-template-areas:
+        "header"
+        "content"
+        ;
+    grid-template-columns: minmax(var(--max-width), 100vw);
+}
+
+/* Constrain and centre main content */
+#main-content {
+    width: 100%;
+    max-width: var(--max-width);
+    margin: auto;
+}
+
+/* Reorder flex children without touching HTML */
+body {
+    display: flex;
+    flex-direction: column;
+}
+#sidebar { order: 1; }
+#content  { order: 2; }
+```
+
+Pair `max-width: var(--max-width)` with a `@var range` so the user can tune it to their viewport and font preferences.
+
+### Z-index and Sticky Positioning
+
+Layering elements above site UI:
+
+```css
+:root {
+    /* Anchor relative to a known site variable */
+    --z-index: calc(var(--ytd-z-index-channel-name) + 1);
+}
+
+#player {
+    position: sticky !important;
+    top: 0;
+    z-index: calc(var(--z-index) + 1);
+}
+```
+
+When a site defines its own z-index custom properties, build on top of them with `calc()` rather than hardcoding large numbers.
+
+### Resetting Problematic Site Styles
+
+Sites sometimes use `overflow: hidden` or `position: fixed` in ways that break scrolling or clip content:
+
+```css
+/* Remove overflow restriction that causes layout issues */
+.claims-table-wrapper {
+    overflow-x: unset;
+}
+
+/* Reset absolute-positioned elements to normal flow */
+#sidebarleft {
+    position: initial;
+    left: auto;
+    top: auto;
+    width: auto;
+    overflow: visible;
+}
+```
+
+`initial` and `unset` are useful when you want to undo a property entirely rather than override it with a specific value.
+
+### Hover-Based Reveal
+
+Override styles conditionally on hover to reveal hidden content:
+
+```css
+/* Reveal spoiler text by matching surrounding text color on hover */
+.spoiler font[color="000000"]:hover {
+    color: inherit !important;
+}
+```
+
+### Typography Overrides
+
+Replace a site's default font stack:
+
+```css
+body {
+    font-family: sans-serif;
+}
+
+/* Monospace for code, sans-serif for UI */
+.code-area {
+    font-family: monospace !important;
+}
+.ui-label {
+    font-family: sans-serif !important;
+}
+```
+
+### Responsive / Media Query Scoping
+
+Apply rules only at certain viewport sizes:
+
+```css
+@media (orientation: portrait), (min-height: 50em) {
+    #player {
+        position: sticky !important;
+        top: 0;
+    }
+}
+```
+
+## Naming Convention
+
+Files are named `<domain>.user.css`. The `@name` in metadata should match or closely reflect the domain.


### PR DESCRIPTION
Adds `usercss/AGENTS.md` and `greasemonkey/AGENTS.md` documenting patterns, conventions, and idioms used across the scripts. Also cleans up a legacy metadata field from all userscripts.

## usercss/AGENTS.md

- Metadata block format: `@name`, `@namespace`, `@version`, `@license`, `@description`
- `@var` declarations: `range` and `select` types, how variables become CSS custom properties
- `@-moz-document` scoping: `domain()`, `url-prefix()`, `regexp()` — prefer narrowest scope
- Why `!important` is the normal tool here (not an antipattern)
- Common patterns: hiding elements, layout overrides (grid/flex), z-index/sticky positioning, resetting site styles with `initial`/`unset`, hover-based reveal, typography overrides, media queries

## greasemonkey/AGENTS.md

- Metadata conventions: `@namespace` + `@name` as unique script identity; do not use `@author` (redundant with `@namespace`)
- GM API categorization:
  - **Fire-and-forget**: `GM.setValue`, `GM.deleteValue`, `GM.openInTab`, `GM.notification`, `GM.setClipboard`, `GM.addStyle`
  - **Synchronous in practice**: `GM_getValue`, `GM_listValues` (VM pre-loads storage — in-memory reads, no async needed)
  - **Await when needed**: `GM.getValue`, `GM.xmlHttpRequest`, `GM.getResourceURL`
- **Eager Promises / Deferred Await**: kick off async operations at script load, do synchronous DOM setup in parallel, `await` only at point of use
- Core patterns: `sleep`, polling loop, `waitFor` with timeout, `VM.observe`, raw `MutationObserver`
- SPA routing: broad `@match` + path gating; note that `return true` from `VM.observe` stops observation permanently — consider whether indefinite observation is needed for multi-route SPAs
- Timing: `requestAnimationFrame` vs `setTimeout(fn, 0)` vs `setTimeout(fn, ms)`
- Event interception: capture-phase listeners for bypassing paste/select blockers
- Auto-submit on paste pattern (2FA forms)
- Keyboard shortcuts via `@violentmonkey/shortcut`
- Cross-origin requests: `GM_xmlhttpRequest` with Promise wrapper for async use
- XPath for text-content queries, idempotency guards, zone.js workaround

## refactor

- Remove `@author` from all 25 userscripts — redundant with `@namespace`, which already encodes authorship and serves as the unique script identity