### PR TITLE
Refactor YouTube ask panel styling with improved z-index handling

### DIFF
--- a/usercss/youtube-ask.com.user.css
+++ b/usercss/youtube-ask.com.user.css
@@ -1,16 +1,17 @@
 /* ==UserStyle==
 @name           Youtube ask
 @namespace      ipwnponies
-@version        1.1.1
+@version        1.1.2
 @description    Make the ask panel a full-screen modal
 ==/UserStyle== */
 
 @-moz-document url-prefix("https://www.youtube.com/watch?v=") {
 
-    /* #primary is video, #secondary are panels. increase z-index priority for stacking context */
+    /* Raise #secondary above #primary (video) by overriding YouTube's z-index variable */
     #secondary {
-        z-index: calc(var(--z-index) + 100);
-        /* This is parent container of ask content, fix it so that it floats and isn't in a corner */
+        z-index: calc(var(--z-index) + 1);
+
+        /* Float #panels as a fixed overlay instead of a sidebar */
         #panels {
             position: fixed !important;
             width: 80vw;
@@ -26,10 +27,9 @@
         }
     }
 
-    /* This is the ask panel, make it full height */
+    /* Allow ask panel to fill the overlay height */
     ytd-engagement-panel-section-list-renderer {
         height: 80vh;
-        /* Override their cap */
         max-height: unset !important;
     }
 }

--- a/usercss/youtube-ask.com.user.css
+++ b/usercss/youtube-ask.com.user.css
@@ -7,21 +7,23 @@
 
 @-moz-document url-prefix("https://www.youtube.com/watch?v=") {
 
-    /* This is parent container, fix it so that it floats and isn't in a corner */
-    #panels {
-        position: fixed !important;
-        width: 80vw;
-        left: 10vw;
-        top: 10vh;
-        opacity: 80%;
-        transition-duration: 1s;
-        z-index: 100;
-    }
+    /* #primary is video, #secondary are panels. increase z-index priority for stacking context */
+    #secondary {
+        z-index: calc(var(--z-index) + 100);
+        /* This is parent container of ask content, fix it so that it floats and isn't in a corner */
+        #panels {
+            position: fixed !important;
+            width: 80vw;
+            left: 10vw;
+            top: 10vh;
+            opacity: 80%;
+            transition-duration: 1s;
+        }
 
-    #panels:hover {
-        opacity: 100%;
-        transition-duration: 0.5s;
-
+        #panels:hover {
+            opacity: 100%;
+            transition-duration: 0.5s;
+        }
     }
 
     /* This is the ask panel, make it full height */


### PR DESCRIPTION
## Summary
Refactored the YouTube ask panel userscript to improve the modal overlay implementation by properly scoping styles and leveraging YouTube's z-index variable system.

## Key Changes
- **Improved z-index management**: Changed from a fixed z-index value (100) to using `calc(var(--z-index) + 1)` to dynamically layer the panel above YouTube's primary content
- **Better CSS scoping**: Moved `#panels` styling into the `#secondary` selector to establish proper parent-child relationships and reduce specificity conflicts
- **Cleaner selectors**: Nested `#panels` and `#panels:hover` rules under `#secondary` for better organization and maintainability
- **Updated comments**: Clarified the purpose of each style rule to better document the implementation approach
- **Version bump**: Updated from 1.1.1 to 1.1.2

## Implementation Details
The refactoring maintains the same visual behavior (80% opacity overlay that becomes 100% on hover, fixed positioning at 10vw/10vh with 80vw width) while improving the underlying CSS architecture. By using YouTube's CSS variable system instead of a hardcoded z-index, the panel will now properly adapt to YouTube's layout changes and avoid conflicts with other overlays.

https://claude.ai/code/session_01R3DqdJsm71LRLobUr6FvFL