### PR TITLE
fix: test runner and null-safe DOM access in userscripts

### DIFF
--- a/greasemonkey/trakt.search-rotten-tomatoes.user.js
+++ b/greasemonkey/trakt.search-rotten-tomatoes.user.js
@@ -3,7 +3,7 @@
 // @namespace   ipwnponies
 // @match       https://trakt.tv/movies/*
 // @grant       GM_registerMenuCommand
-// @version     1.1
+// @version     1.1.1
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add a link to search movie on rotten tomatoes
 // ==/UserScript==
@@ -22,7 +22,7 @@ rtLink.href = `https://www.rottentomatoes.com/search?search=${getMovieName()}`;
 
 const main = () => {
   const externalLinkContainer = document.querySelector('.external > li');
-  externalLinkContainer.append(rtLink);
+  externalLinkContainer?.append(rtLink);
 };
 
 main();

--- a/greasemonkey/youtube.show-transcript-hotkey.user.js
+++ b/greasemonkey/youtube.show-transcript-hotkey.user.js
@@ -3,7 +3,7 @@
 // @namespace   ipwnponies
 // @match       https://www.youtube.com/watch*
 // @grant       none
-// @version     1.0
+// @version     1.0.1
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Add hotkey to click the show transcript button.
 // ==/UserScript==
@@ -11,5 +11,5 @@ const { register } = VM.shortcut;
 
 register('ctrl-k', () => {
   const showTranscript = document.querySelector('#description [aria-label="Show transcript"]');
-  showTranscript.click();
+  showTranscript?.click();
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My collection of greasemonkey scripts",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/**"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- **fix: wire up test script** — `package.json` test script was a placeholder that always exited 1. Now runs the actual test suite under `tests/` via Node's built-in test runner (`node --test tests/**`).
- **fix(userscript): guard against missing element** — Both `youtube.show-transcript-hotkey` and `trakt.search-rotten-tomatoes` would throw a `TypeError` if the expected DOM element wasn't present (e.g. video without a transcript, or trakt page missing the external links section). Fixed with optional chaining (`?.`). Patch version bumped on both scripts.

## Test plan

- [ ] `npm test` passes
- [ ] On a YouTube video with a transcript, `ctrl-k` opens the transcript panel
- [ ] On a YouTube video without a transcript, `ctrl-k` is a no-op (no console error)
- [ ] On a trakt movie page with external links, the Rotten Tomatoes link appears
- [ ] On a trakt movie page without external links, no console error

https://claude.ai/code/session_01X76dwid5rpZWNpSwupiqkW