### PR TITLE
Add keyboard shortcuts and command palette for claude.ai

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,7 @@ env:
 globals:
   # Violentmonkey APIs
   VM: readonly
+  GM: readonly
   # Greasemonkey/Violentmonkey GM_ APIs (declared per-script via @grant but used as globals)
   GM_getValue: readonly
   GM_xmlhttpRequest: readonly

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -10,16 +10,16 @@
 
 const { register } = VM.shortcut;
 
-// Primary: button's full text is exactly the mode name (no extraneous child text).
-// Fallback: button contains a <span> with exactly the mode name (handles SVG-with-title siblings).
-const XPATH_MODE = '//button['
-  + 'normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"'
-  + ' or .//span[normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"]'
-  + ']';
-const XPATH_MODEL = '//button['
+// aria-haspopup="menu" constrains to toolbar dropdowns, excluding sidebar nav items.
+// Accept mode shows "Accept edits" so use contains() rather than equality.
+const XPATH_MODE = '//button[@aria-haspopup="menu" and ('
+  + 'normalize-space(.)="Plan" or normalize-space(.)="Auto" or contains(normalize-space(.),"Accept")'
+  + ')]';
+// Same aria-haspopup guard prevents matching conversation titles ("Claude.ai ...") in sidebar.
+const XPATH_MODEL = '//button[@aria-haspopup="menu" and ('
   + 'contains(normalize-space(.),"Claude") or contains(normalize-space(.),"Sonnet")'
   + ' or contains(normalize-space(.),"Haiku") or contains(normalize-space(.),"Opus")'
-  + ']';
+  + ')]';
 
 // --- Utilities ---
 
@@ -71,11 +71,9 @@ const clickMic = () => {
   startEl.dispatchEvent(new MouseEvent('click', pOpts));
 };
 
-/* node:coverage ignore next 4 */
+/* node:coverage ignore next 3 */
 const clickModelSelector = () => {
-  const el = document.querySelector('button[aria-label*="model" i]')
-    ?? findByXPath(XPATH_MODEL);
-  clickOrWarn(el, 'model selector');
+  clickOrWarn(findByXPath(XPATH_MODEL), 'model selector');
 };
 
 /* node:coverage ignore next 5 */

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -33,14 +33,37 @@ const clickOrWarn = (el, name) => {
   }
 };
 
+/* node:coverage ignore next 8 */
+const showToast = (msg) => {
+  const t = document.createElement('div');
+  t.style.cssText = 'position:fixed;bottom:80px;left:50%;transform:translateX(-50%);'
+    + 'background:#333;color:#fff;padding:8px 16px;border-radius:6px;'
+    + 'font-size:13px;z-index:2147483647;pointer-events:none;transition:opacity 0.3s';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => { t.style.opacity = '0'; setTimeout(() => t.remove(), 300); }, 2000);
+};
+
 // --- Actions ---
 
-/* node:coverage ignore next 5 */
+/* node:coverage ignore next 18 */
 const clickMic = () => {
-  const el = document.querySelector('button[aria-label="Stop dictation"]')
-    ?? document.querySelector('button[aria-label="Finish dictation"]')
-    ?? document.querySelector('button[aria-label="Press and hold to record"]');
-  clickOrWarn(el, 'microphone');
+  const stopEl = document.querySelector('button[aria-label="Stop dictation"]')
+    ?? document.querySelector('button[aria-label="Finish dictation"]');
+  if (stopEl) { stopEl.click(); return; }
+  const startEl = document.querySelector('button[aria-label="Press and hold to record"]');
+  if (!startEl) {
+    // eslint-disable-next-line no-console
+    console.warn('[claude-shortcuts] microphone button not found');
+    return;
+  }
+  const pOpts = { bubbles: true, cancelable: true, button: 0 };
+  startEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+  startEl.dispatchEvent(new PointerEvent('pointerdown', { ...pOpts, isPrimary: true }));
+  startEl.dispatchEvent(new MouseEvent('mousedown', pOpts));
+  startEl.dispatchEvent(new PointerEvent('pointerup', { ...pOpts, isPrimary: true }));
+  startEl.dispatchEvent(new MouseEvent('mouseup', pOpts));
+  startEl.dispatchEvent(new MouseEvent('click', pOpts));
 };
 
 /* node:coverage ignore next 4 */
@@ -50,9 +73,11 @@ const clickModelSelector = () => {
   clickOrWarn(el, 'model selector');
 };
 
-/* node:coverage ignore next 3 */
+/* node:coverage ignore next 5 */
 const clickModeToggle = () => {
-  clickOrWarn(findByXPath(XPATH_MODE), 'mode toggle');
+  const el = findByXPath(XPATH_MODE);
+  if (!el) { showToast('Mode toggle not available here'); return; }
+  el.click();
 };
 
 /* node:coverage ignore next 5 */

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -37,9 +37,8 @@ const clickOrWarn = (el, name) => {
 
 /* node:coverage ignore next 5 */
 const clickMic = () => {
-  const el = document.querySelector('button[aria-label*="voice" i]')
-    ?? document.querySelector('button[aria-label*="microphone" i]')
-    ?? document.querySelector('button[aria-label*="record" i]');
+  const el = document.querySelector('button[aria-label="Stop dictation"]')
+    ?? document.querySelector('button[aria-label="Press and hold to record"]');
   clickOrWarn(el, 'microphone');
 };
 
@@ -70,12 +69,13 @@ const clickFileAttach = () => {
 
 const COMMANDS = [
   { label: 'Toggle microphone', shortcut: 'Ctrl+D', action: clickMic },
-  { label: 'Open model selector', shortcut: 'Ctrl+Shift+I', action: clickModelSelector },
-  { label: 'Toggle mode (Plan/Accept/Auto)', shortcut: 'Ctrl+Shift+M', action: clickModeToggle },
-  { label: 'Attach file', shortcut: 'Ctrl+U', action: clickFileAttach },
+  { label: 'Open model selector', action: clickModelSelector },
+  { label: 'Toggle mode (Plan/Accept/Auto)', action: clickModeToggle },
+  { label: 'Attach file', action: clickFileAttach },
 ];
 
 const NATIVE_SHORTCUTS = [
+  { label: 'Open script command palette', shortcut: 'Ctrl+P' },
   { label: 'Open Claude command palette', shortcut: 'Ctrl+K' },
   { label: 'New conversation', shortcut: 'Ctrl+Shift+O' },
   { label: 'Submit message', shortcut: 'Enter' },
@@ -169,20 +169,17 @@ GM.addStyle(`
   }
 `);
 
-/* node:coverage ignore next 5 */
 const setSelected = (items, idx) => {
   for (const item of items) item.removeAttribute('aria-selected');
   items[idx]?.setAttribute('aria-selected', 'true');
   items[idx]?.scrollIntoView({ block: 'nearest' });
 };
 
-/* node:coverage ignore next 4 */
 const makeCommandClickHandler = (cmd) => () => {
   paletteDialog.close();
   cmd.action();
 };
 
-/* node:coverage disable */
 const renderPaletteItems = () => {
   const query = paletteSearch.value.toLowerCase();
   paletteList.innerHTML = '';
@@ -202,7 +199,7 @@ const renderPaletteItems = () => {
       const li = document.createElement('li');
       li.className = 'ipwnponies-palette-item';
       li.setAttribute('role', 'option');
-      li.innerHTML = `<span>${cmd.label}</span><span class="ipwnponies-palette-shortcut">${cmd.shortcut}</span>`;
+      li.innerHTML = `<span>${cmd.label}</span><span class="ipwnponies-palette-shortcut">${cmd.shortcut ?? ''}</span>`;
       li.addEventListener('click', makeCommandClickHandler(cmd));
       paletteList.appendChild(li);
     }
@@ -227,6 +224,7 @@ const renderPaletteItems = () => {
   if (firstItem) firstItem.setAttribute('aria-selected', 'true');
 };
 
+/* node:coverage ignore next 44 */
 const injectPalette = () => {
   if (document.querySelector('#ipwnponies-palette')) return;
 
@@ -285,18 +283,13 @@ const togglePalette = () => {
   }
 };
 
-/* node:coverage enable */
-
 // --- Init ---
 
 /* node:coverage disable */
 injectPalette();
 
 register('ctrl-d', clickMic);
-register('ctrl-shift-i', clickModelSelector);
-register('ctrl-shift-m', clickModeToggle);
-register('ctrl-u', clickFileAttach);
-register('ctrl-shift-p', togglePalette);
+register('ctrl-p', togglePalette);
 /* node:coverage enable */
 
 // Exported for unit tests only — not used in browser context.

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -45,12 +45,20 @@ const clickMic = () => {
   startEl.dispatchEvent(new MouseEvent('click', pOpts));
 };
 
-/* node:coverage ignore next 6 */
+/* node:coverage ignore next 11 */
 const clickModelSelector = () => {
-  // Ctrl+Alt+I — native Claude Code shortcut; also dispatched in chat (no-op if unhandled there)
-  document.body.dispatchEvent(new KeyboardEvent('keydown', {
-    ctrlKey: true, altKey: true, key: 'i', bubbles: true, cancelable: true,
-  }));
+  if (window.location.pathname.startsWith('/code')) {
+    // Ctrl+Alt+I — native Claude Code shortcut
+    document.body.dispatchEvent(new KeyboardEvent('keydown', {
+      ctrlKey: true, altKey: true, key: 'i', bubbles: true, cancelable: true,
+    }));
+    return;
+  }
+  // Claude Chat: no native shortcut — find model dropdown button by aria-haspopup + model name text
+  const btn = [...document.querySelectorAll('button[aria-haspopup="menu"]')]
+    .find((b) => /\b(Claude|Sonnet|Haiku|Opus)\b/i.test(b.textContent));
+  // eslint-disable-next-line no-console
+  if (btn) btn.click(); else console.warn('[claude-shortcuts] model selector button not found');
 };
 
 /* node:coverage ignore next 7 */

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -10,7 +10,12 @@
 
 const { register } = VM.shortcut;
 
-const XPATH_MODE = '//button[normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"]';
+// Primary: button's full text is exactly the mode name (no extraneous child text).
+// Fallback: button contains a <span> with exactly the mode name (handles SVG-with-title siblings).
+const XPATH_MODE = '//button['
+  + 'normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"'
+  + ' or .//span[normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"]'
+  + ']';
 const XPATH_MODEL = '//button['
   + 'contains(normalize-space(.),"Claude") or contains(normalize-space(.),"Sonnet")'
   + ' or contains(normalize-space(.),"Haiku") or contains(normalize-space(.),"Opus")'
@@ -219,9 +224,12 @@ const setSelected = (items, idx) => {
   items[idx]?.scrollIntoView({ block: 'nearest' });
 };
 
+// Defer action so the Enter keydown that triggered this click finishes propagating
+// before we dispatch synthetic shortcuts — otherwise the event leaks into any
+// native palette that opens (e.g. Ctrl+K palette grabbing the still-bubbling Enter).
 const makeCommandClickHandler = (cmd) => () => {
   paletteDialog.close();
-  cmd.action();
+  setTimeout(cmd.action, 0);
 };
 
 // Dispatches a keyboard event to document.body without closing the palette —
@@ -325,12 +333,15 @@ const injectPalette = () => {
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();
+      e.stopPropagation();
       setSelected(items, getNextIndex(selectedIdx, items.length, 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
+      e.stopPropagation();
       setSelected(items, getNextIndex(selectedIdx, items.length, -1));
     } else if (e.key === 'Enter') {
       e.preventDefault();
+      e.stopPropagation();
       items[selectedIdx]?.click();
     }
   });

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -45,32 +45,23 @@ const clickMic = () => {
   startEl.dispatchEvent(new MouseEvent('click', pOpts));
 };
 
-/* node:coverage ignore next 11 */
+/* node:coverage ignore next 6 */
 const clickModelSelector = () => {
-  if (window.location.pathname.startsWith('/code')) {
-    // Ctrl+Alt+I — native Claude Code shortcut
-    document.body.dispatchEvent(new KeyboardEvent('keydown', {
-      ctrlKey: true, altKey: true, key: 'i', bubbles: true, cancelable: true,
-    }));
-    return;
-  }
-  // Claude Chat: no native shortcut — find model dropdown button by aria-haspopup + model name text
   const btn = [...document.querySelectorAll('button[aria-haspopup="menu"]')]
     .find((b) => /\b(Claude|Sonnet|Haiku|Opus)\b/i.test(b.textContent));
   // eslint-disable-next-line no-console
   if (btn) btn.click(); else console.warn('[claude-shortcuts] model selector button not found');
 };
 
-/* node:coverage ignore next 7 */
+/* node:coverage ignore next 8 */
 const clickModeToggle = () => {
   if (!window.location.pathname.startsWith('/code')) {
     showToast('Mode toggle not available here');
     return;
   }
-  // Ctrl+Alt+M — native Claude Code shortcut
-  document.body.dispatchEvent(new KeyboardEvent('keydown', {
-    ctrlKey: true, altKey: true, key: 'm', bubbles: true, cancelable: true,
-  }));
+  const btn = [...document.querySelectorAll('button[aria-haspopup="menu"]')]
+    .find((b) => /\b(Plan|Auto)\b/.test(b.textContent) || b.textContent.includes('Accept'));
+  if (btn) btn.click(); else showToast('Mode toggle button not found');
 };
 
 /* node:coverage ignore next 5 */

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -1,0 +1,277 @@
+// ==UserScript==
+// @name        Desktop shortcuts - claude.ai
+// @namespace   ipwnponies
+// @match       https://claude.ai/*
+// @grant       GM.addStyle
+// @version     1.0.0
+// @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
+// @description Keyboard shortcuts for mic, model, mode, file attach, and command palette
+// ==/UserScript==
+
+const { register } = VM.shortcut;
+
+const XPATH_MODE = '//button[normalize-space(.)="Plan" or normalize-space(.)="Accept" or normalize-space(.)="Auto"]';
+const XPATH_MODEL = '//button['
+  + 'contains(normalize-space(.),"Claude") or contains(normalize-space(.),"Sonnet")'
+  + ' or contains(normalize-space(.),"Haiku") or contains(normalize-space(.),"Opus")'
+  + ']';
+
+// --- Utilities ---
+
+const findByXPath = (xpath) => document.evaluate(
+  xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null,
+).singleNodeValue;
+
+const clickOrWarn = (el, name) => {
+  if (el) {
+    el.click();
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(`[claude-shortcuts] ${name} button not found`);
+  }
+};
+
+// --- Actions ---
+
+const clickMic = () => {
+  const el = document.querySelector('button[aria-label*="voice" i]')
+    ?? document.querySelector('button[aria-label*="microphone" i]')
+    ?? document.querySelector('button[aria-label*="record" i]');
+  clickOrWarn(el, 'microphone');
+};
+
+const clickModelSelector = () => {
+  const el = document.querySelector('button[aria-label*="model" i]')
+    ?? findByXPath(XPATH_MODEL);
+  clickOrWarn(el, 'model selector');
+};
+
+const clickModeToggle = () => {
+  const el = findByXPath(XPATH_MODE)
+    ?? document.querySelector('button[aria-haspopup="menu"]');
+  clickOrWarn(el, 'mode toggle');
+};
+
+const clickFileAttach = () => {
+  const el = document.querySelector('button[aria-label*="attach" i]')
+    ?? document.querySelector('button[aria-label*="file" i]')
+    ?? document.querySelector('button[aria-label*="upload" i]')
+    ?? document.querySelector('input[type="file"]');
+  clickOrWarn(el, 'file attach');
+};
+
+// --- Command palette ---
+
+const COMMANDS = [
+  { label: 'Toggle microphone', shortcut: 'Ctrl+D', action: clickMic },
+  { label: 'Open model selector', shortcut: 'Ctrl+Shift+I', action: clickModelSelector },
+  { label: 'Toggle mode (Plan/Accept/Auto)', shortcut: 'Ctrl+Shift+M', action: clickModeToggle },
+  { label: 'Attach file', shortcut: 'Ctrl+U', action: clickFileAttach },
+];
+
+const NATIVE_SHORTCUTS = [
+  { label: 'Open Claude command palette', shortcut: 'Ctrl+K' },
+  { label: 'New conversation', shortcut: 'Ctrl+Shift+O' },
+  { label: 'Submit message', shortcut: 'Enter' },
+  { label: 'New line in message', shortcut: 'Shift+Enter' },
+];
+
+let paletteDialog = null;
+let paletteSearch = null;
+let paletteList = null;
+
+GM.addStyle(`
+  #ipwnponies-palette {
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+    width: 480px;
+    max-width: 90vw;
+    background: #1a1a1a;
+    color: #e5e5e5;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  }
+  #ipwnponies-palette::backdrop {
+    background: rgba(0,0,0,0.4);
+  }
+  #ipwnponies-palette-search {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #333;
+    color: inherit;
+    font-size: 14px;
+    outline: none;
+  }
+  #ipwnponies-palette-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .ipwnponies-palette-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .ipwnponies-palette-item:hover,
+  .ipwnponies-palette-item[aria-selected="true"] {
+    background: #2a2a2a;
+  }
+  .ipwnponies-palette-item[aria-selected="true"] {
+    outline: 1px solid #555;
+    outline-offset: -1px;
+  }
+  .ipwnponies-palette-shortcut {
+    font-size: 11px;
+    color: #888;
+    font-family: monospace;
+    flex-shrink: 0;
+    margin-left: 16px;
+  }
+  .ipwnponies-palette-section {
+    padding: 6px 16px 2px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #666;
+  }
+  .ipwnponies-palette-item.native {
+    color: #888;
+    cursor: default;
+  }
+  .ipwnponies-palette-item.native:hover,
+  .ipwnponies-palette-item.native[aria-selected="true"] {
+    background: transparent;
+    outline: none;
+  }
+`);
+
+const setSelected = (items, idx) => {
+  for (const item of items) item.removeAttribute('aria-selected');
+  items[idx]?.setAttribute('aria-selected', 'true');
+  items[idx]?.scrollIntoView({ block: 'nearest' });
+};
+
+const makeCommandClickHandler = (cmd) => () => {
+  paletteDialog.close();
+  cmd.action();
+};
+
+const renderPaletteItems = () => {
+  const query = paletteSearch.value.toLowerCase();
+  paletteList.innerHTML = '';
+
+  const filtered = COMMANDS.filter((c) => c.label.toLowerCase().includes(query));
+  const filteredNative = query ? [] : NATIVE_SHORTCUTS;
+
+  if (filtered.length) {
+    if (!query) {
+      const section = document.createElement('li');
+      section.className = 'ipwnponies-palette-section';
+      section.textContent = 'Script commands';
+      paletteList.appendChild(section);
+    }
+
+    for (const cmd of filtered) {
+      const li = document.createElement('li');
+      li.className = 'ipwnponies-palette-item';
+      li.setAttribute('role', 'option');
+      li.innerHTML = `<span>${cmd.label}</span><span class="ipwnponies-palette-shortcut">${cmd.shortcut}</span>`;
+      li.addEventListener('click', makeCommandClickHandler(cmd));
+      paletteList.appendChild(li);
+    }
+  }
+
+  if (filteredNative.length) {
+    const section = document.createElement('li');
+    section.className = 'ipwnponies-palette-section';
+    section.textContent = 'Native shortcuts';
+    paletteList.appendChild(section);
+
+    for (const sc of filteredNative) {
+      const li = document.createElement('li');
+      li.className = 'ipwnponies-palette-item native';
+      li.setAttribute('role', 'option');
+      li.innerHTML = `<span>${sc.label}</span><span class="ipwnponies-palette-shortcut">${sc.shortcut}</span>`;
+      paletteList.appendChild(li);
+    }
+  }
+
+  const firstItem = paletteList.querySelector('.ipwnponies-palette-item:not(.native)');
+  if (firstItem) firstItem.setAttribute('aria-selected', 'true');
+};
+
+const injectPalette = () => {
+  if (document.querySelector('#ipwnponies-palette')) return;
+
+  paletteDialog = document.createElement('dialog');
+  paletteDialog.id = 'ipwnponies-palette';
+
+  paletteSearch = document.createElement('input');
+  paletteSearch.id = 'ipwnponies-palette-search';
+  paletteSearch.type = 'search';
+  paletteSearch.placeholder = 'Search commands…';
+  paletteSearch.autocomplete = 'off';
+
+  paletteList = document.createElement('ul');
+  paletteList.id = 'ipwnponies-palette-list';
+  paletteList.setAttribute('role', 'listbox');
+
+  paletteDialog.appendChild(paletteSearch);
+  paletteDialog.appendChild(paletteList);
+  document.body.appendChild(paletteDialog);
+
+  paletteSearch.addEventListener('input', renderPaletteItems);
+
+  paletteSearch.addEventListener('keydown', (e) => {
+    const items = [...paletteList.querySelectorAll('.ipwnponies-palette-item:not(.native)')];
+    if (!items.length) return;
+
+    const selectedIdx = items.findIndex((i) => i.getAttribute('aria-selected') === 'true');
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelected(items, selectedIdx < items.length - 1 ? selectedIdx + 1 : 0);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelected(items, selectedIdx > 0 ? selectedIdx - 1 : items.length - 1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      items[selectedIdx]?.click();
+    }
+  });
+
+  // Close on backdrop click (dialog element itself, not its children)
+  paletteDialog.addEventListener('click', (e) => {
+    if (e.target === paletteDialog) paletteDialog.close();
+  });
+};
+
+const togglePalette = () => {
+  if (!paletteDialog) return;
+  if (paletteDialog.open) {
+    paletteDialog.close();
+  } else {
+    paletteSearch.value = '';
+    renderPaletteItems();
+    paletteDialog.showModal();
+    paletteSearch.focus();
+  }
+};
+
+// --- Init ---
+
+injectPalette();
+
+register('ctrl-d', clickMic);
+register('ctrl-shift-i', clickModelSelector);
+register('ctrl-shift-m', clickModeToggle);
+register('ctrl-u', clickFileAttach);
+register('ctrl-shift-p', togglePalette);

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -3,7 +3,7 @@
 // @namespace   ipwnponies
 // @match       https://claude.ai/*
 // @grant       GM.addStyle
-// @version     1.0.0
+// @version     1.1.0
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @description Mic hotkey and command palette for claude.ai
 // ==/UserScript==

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -78,8 +78,10 @@ const COMMANDS = [
 const filterCommands = (query) => COMMANDS.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()));
 
 // Pure: next arrow-key index with wrapping. direction: 1 (down) or -1 (up).
+// current === -1 means no item is selected.
 const getNextIndex = (current, total, direction) => {
   if (total === 0) return -1;
+  if (current === -1) return direction === 1 ? 0 : total - 1;
   return (current + direction + total) % total;
 };
 
@@ -96,11 +98,15 @@ const parseShortcut = (str) => {
   };
 };
 
-/* node:coverage ignore next 4 */
+/* node:coverage ignore next 5 */
 let paletteDialog = null;
+let paletteHandle = null;
 let paletteSearch = null;
 let paletteList = null;
 let palettePos = null; // { left, top } retained for the tab session
+
+// Cached list of palette items — invalidated by renderPaletteItems, read by keydown handler.
+let cachedItems = [];
 
 GM.addStyle(`
   #ipwnponies-palette {
@@ -112,9 +118,25 @@ GM.addStyle(`
     background: #1a1a1a;
     color: #e5e5e5;
     box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+    /* Explicit centering — overrides any page CSS that resets UA margin:auto */
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
   }
   #ipwnponies-palette::backdrop {
     background: rgba(0,0,0,0.4);
+  }
+  #ipwnponies-palette-handle {
+    padding: 7px 16px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #555;
+    cursor: move;
+    user-select: none;
+    border-bottom: 1px solid #222;
   }
   #ipwnponies-palette-search {
     width: 100%;
@@ -126,12 +148,6 @@ GM.addStyle(`
     color: inherit;
     font-size: 14px;
     outline: none;
-    cursor: move;
-    user-select: none;
-  }
-  #ipwnponies-palette-search:focus {
-    cursor: text;
-    user-select: auto;
   }
   #ipwnponies-palette-list {
     list-style: none;
@@ -246,6 +262,9 @@ const renderPaletteItems = () => {
 
   const firstItem = paletteList.querySelector('.ipwnponies-palette-item');
   if (firstItem) firstItem.setAttribute('aria-selected', 'true');
+
+  // Invalidate cache after every render.
+  cachedItems = [...paletteList.querySelectorAll('.ipwnponies-palette-item')];
 };
 
 const injectPalette = () => {
@@ -253,6 +272,10 @@ const injectPalette = () => {
 
   paletteDialog = document.createElement('dialog');
   paletteDialog.id = 'ipwnponies-palette';
+
+  paletteHandle = document.createElement('div');
+  paletteHandle.id = 'ipwnponies-palette-handle';
+  paletteHandle.textContent = 'Commands';
 
   paletteSearch = document.createElement('input');
   paletteSearch.id = 'ipwnponies-palette-search';
@@ -264,6 +287,7 @@ const injectPalette = () => {
   paletteList.id = 'ipwnponies-palette-list';
   paletteList.setAttribute('role', 'listbox');
 
+  paletteDialog.appendChild(paletteHandle);
   paletteDialog.appendChild(paletteSearch);
   paletteDialog.appendChild(paletteList);
   document.body.appendChild(paletteDialog);
@@ -271,7 +295,8 @@ const injectPalette = () => {
   paletteSearch.addEventListener('input', renderPaletteItems);
 
   paletteSearch.addEventListener('keydown', (e) => {
-    const items = [...paletteList.querySelectorAll('.ipwnponies-palette-item')];
+    // Use cached items — invalidated by renderPaletteItems on every input event.
+    const items = cachedItems;
     if (!items.length) return;
 
     const selectedIdx = items.findIndex((i) => i.getAttribute('aria-selected') === 'true');
@@ -292,22 +317,47 @@ const injectPalette = () => {
     if (e.target === paletteDialog) paletteDialog.close();
   });
 
-  // Drag by the search bar; position is stored for the session.
-  paletteSearch.addEventListener('mousedown', (e) => {
+  // Drag via the handle bar. Separate from the search input to avoid
+  // suppressing focus/selection on the text field.
+  let dragCleanup = null;
+
+  paletteDialog.addEventListener('close', () => {
+    if (dragCleanup) {
+      dragCleanup();
+      dragCleanup = null;
+    }
+  });
+
+  paletteHandle.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return;
+
+    // Commit the current visual position to left/top before measuring so the
+    // coordinate frame is consistent throughout the drag.
+    paletteDialog.style.transform = 'none';
+    paletteDialog.style.margin = '0';
+    if (!palettePos) {
+      const r = paletteDialog.getBoundingClientRect();
+      paletteDialog.style.left = `${r.left}px`;
+      paletteDialog.style.top = `${r.top}px`;
+    }
+
     const rect = paletteDialog.getBoundingClientRect();
     const offsetX = e.clientX - rect.left;
     const offsetY = e.clientY - rect.top;
+
     const onMove = (ev) => {
       palettePos = { left: ev.clientX - offsetX, top: ev.clientY - offsetY };
       paletteDialog.style.left = `${palettePos.left}px`;
       paletteDialog.style.top = `${palettePos.top}px`;
-      paletteDialog.style.margin = '0';
     };
+
     const onUp = () => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
+      dragCleanup = null;
     };
+
+    dragCleanup = onUp;
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
     e.preventDefault();
@@ -323,9 +373,10 @@ const togglePalette = () => {
     renderPaletteItems();
     paletteDialog.showModal();
     if (palettePos) {
+      paletteDialog.style.transform = 'none';
+      paletteDialog.style.margin = '0';
       paletteDialog.style.left = `${palettePos.left}px`;
       paletteDialog.style.top = `${palettePos.top}px`;
-      paletteDialog.style.margin = '0';
     }
     paletteSearch.focus();
   }

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -10,33 +10,7 @@
 
 const { register } = VM.shortcut;
 
-// aria-haspopup="menu" constrains to toolbar dropdowns, excluding sidebar nav items.
-// Accept mode shows "Accept edits" so use contains() rather than equality.
-const XPATH_MODE = '//button[@aria-haspopup="menu" and ('
-  + 'normalize-space(.)="Plan" or normalize-space(.)="Auto" or contains(normalize-space(.),"Accept")'
-  + ')]';
-// Same aria-haspopup guard prevents matching conversation titles ("Claude.ai ...") in sidebar.
-const XPATH_MODEL = '//button[@aria-haspopup="menu" and ('
-  + 'contains(normalize-space(.),"Claude") or contains(normalize-space(.),"Sonnet")'
-  + ' or contains(normalize-space(.),"Haiku") or contains(normalize-space(.),"Opus")'
-  + ')]';
-
 // --- Utilities ---
-
-/* node:coverage ignore next 3 */
-const findByXPath = (xpath) => document.evaluate(
-  xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null,
-).singleNodeValue;
-
-/* node:coverage ignore next 7 */
-const clickOrWarn = (el, name) => {
-  if (el) {
-    el.click();
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn(`[claude-shortcuts] ${name} button not found`);
-  }
-};
 
 /* node:coverage ignore next 8 */
 const showToast = (msg) => {
@@ -71,16 +45,24 @@ const clickMic = () => {
   startEl.dispatchEvent(new MouseEvent('click', pOpts));
 };
 
-/* node:coverage ignore next 3 */
+/* node:coverage ignore next 6 */
 const clickModelSelector = () => {
-  clickOrWarn(findByXPath(XPATH_MODEL), 'model selector');
+  // Ctrl+Alt+I — native Claude Code shortcut; also dispatched in chat (no-op if unhandled there)
+  document.body.dispatchEvent(new KeyboardEvent('keydown', {
+    ctrlKey: true, altKey: true, key: 'i', bubbles: true, cancelable: true,
+  }));
 };
 
-/* node:coverage ignore next 5 */
+/* node:coverage ignore next 7 */
 const clickModeToggle = () => {
-  const el = findByXPath(XPATH_MODE);
-  if (!el) { showToast('Mode toggle not available here'); return; }
-  el.click();
+  if (!window.location.pathname.startsWith('/code')) {
+    showToast('Mode toggle not available here');
+    return;
+  }
+  // Ctrl+Alt+M — native Claude Code shortcut
+  document.body.dispatchEvent(new KeyboardEvent('keydown', {
+    ctrlKey: true, altKey: true, key: 'm', bubbles: true, cancelable: true,
+  }));
 };
 
 /* node:coverage ignore next 5 */

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -5,7 +5,7 @@
 // @grant       GM.addStyle
 // @version     1.0.0
 // @require     https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
-// @description Keyboard shortcuts for mic, model, mode, file attach, and command palette
+// @description Mic hotkey and command palette for claude.ai
 // ==/UserScript==
 
 const { register } = VM.shortcut;
@@ -74,14 +74,6 @@ const COMMANDS = [
   { label: 'Attach file', action: clickFileAttach },
 ];
 
-const NATIVE_SHORTCUTS = [
-  { label: 'Open script command palette', shortcut: 'Ctrl+P' },
-  { label: 'Open Claude command palette', shortcut: 'Ctrl+K' },
-  { label: 'New conversation', shortcut: 'Ctrl+Shift+O' },
-  { label: 'Submit message', shortcut: 'Enter' },
-  { label: 'New line in message', shortcut: 'Shift+Enter' },
-];
-
 // Pure: returns COMMANDS entries whose label contains query (case-insensitive).
 const filterCommands = (query) => COMMANDS.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()));
 
@@ -91,10 +83,24 @@ const getNextIndex = (current, total, direction) => {
   return (current + direction + total) % total;
 };
 
-/* node:coverage ignore next 3 */
+// Pure: parses "Ctrl+Shift+K" into a KeyboardEvent init dict.
+const parseShortcut = (str) => {
+  const parts = str.split('+');
+  const key = parts[parts.length - 1];
+  return {
+    ctrlKey: parts.includes('Ctrl'),
+    shiftKey: parts.includes('Shift'),
+    altKey: parts.includes('Alt'),
+    metaKey: parts.includes('Meta'),
+    key: key.length === 1 ? key.toLowerCase() : key,
+  };
+};
+
+/* node:coverage ignore next 4 */
 let paletteDialog = null;
 let paletteSearch = null;
 let paletteList = null;
+let palettePos = null; // { left, top } retained for the tab session
 
 GM.addStyle(`
   #ipwnponies-palette {
@@ -120,6 +126,12 @@ GM.addStyle(`
     color: inherit;
     font-size: 14px;
     outline: none;
+    cursor: move;
+    user-select: none;
+  }
+  #ipwnponies-palette-search:focus {
+    cursor: text;
+    user-select: auto;
   }
   #ipwnponies-palette-list {
     list-style: none;
@@ -159,13 +171,7 @@ GM.addStyle(`
     color: #666;
   }
   .ipwnponies-palette-item.native {
-    color: #888;
-    cursor: default;
-  }
-  .ipwnponies-palette-item.native:hover,
-  .ipwnponies-palette-item.native[aria-selected="true"] {
-    background: transparent;
-    outline: none;
+    color: #aaa;
   }
 `);
 
@@ -180,6 +186,23 @@ const makeCommandClickHandler = (cmd) => () => {
   cmd.action();
 };
 
+// Dispatches a keyboard event to document.body without closing the palette —
+// callers are responsible for closing first via makeCommandClickHandler.
+/* node:coverage ignore next 4 */
+const dispatchShortcut = (str) => {
+  const opts = parseShortcut(str);
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { ...opts, bubbles: true, cancelable: true }));
+};
+
+// Must be defined before renderPaletteItems which iterates over it.
+const NATIVE_SHORTCUTS = [
+  { label: 'Open Claude command palette', shortcut: 'Ctrl+K', action: () => dispatchShortcut('Ctrl+K') },
+  { label: 'New conversation', shortcut: 'Ctrl+Shift+O', action: () => dispatchShortcut('Ctrl+Shift+O') },
+  { label: 'Submit message', shortcut: 'Enter', action: () => dispatchShortcut('Enter') },
+  { label: 'New line in message', shortcut: 'Shift+Enter', action: () => dispatchShortcut('Shift+Enter') },
+];
+
+/* node:coverage disable */
 const renderPaletteItems = () => {
   const query = paletteSearch.value.toLowerCase();
   paletteList.innerHTML = '';
@@ -216,15 +239,15 @@ const renderPaletteItems = () => {
       li.className = 'ipwnponies-palette-item native';
       li.setAttribute('role', 'option');
       li.innerHTML = `<span>${sc.label}</span><span class="ipwnponies-palette-shortcut">${sc.shortcut}</span>`;
+      li.addEventListener('click', makeCommandClickHandler(sc));
       paletteList.appendChild(li);
     }
   }
 
-  const firstItem = paletteList.querySelector('.ipwnponies-palette-item:not(.native)');
+  const firstItem = paletteList.querySelector('.ipwnponies-palette-item');
   if (firstItem) firstItem.setAttribute('aria-selected', 'true');
 };
 
-/* node:coverage ignore next 44 */
 const injectPalette = () => {
   if (document.querySelector('#ipwnponies-palette')) return;
 
@@ -248,7 +271,7 @@ const injectPalette = () => {
   paletteSearch.addEventListener('input', renderPaletteItems);
 
   paletteSearch.addEventListener('keydown', (e) => {
-    const items = [...paletteList.querySelectorAll('.ipwnponies-palette-item:not(.native)')];
+    const items = [...paletteList.querySelectorAll('.ipwnponies-palette-item')];
     if (!items.length) return;
 
     const selectedIdx = items.findIndex((i) => i.getAttribute('aria-selected') === 'true');
@@ -265,9 +288,29 @@ const injectPalette = () => {
     }
   });
 
-  // Close on backdrop click (dialog element itself, not its children)
   paletteDialog.addEventListener('click', (e) => {
     if (e.target === paletteDialog) paletteDialog.close();
+  });
+
+  // Drag by the search bar; position is stored for the session.
+  paletteSearch.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    const rect = paletteDialog.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const onMove = (ev) => {
+      palettePos = { left: ev.clientX - offsetX, top: ev.clientY - offsetY };
+      paletteDialog.style.left = `${palettePos.left}px`;
+      paletteDialog.style.top = `${palettePos.top}px`;
+      paletteDialog.style.margin = '0';
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    e.preventDefault();
   });
 };
 
@@ -279,9 +322,15 @@ const togglePalette = () => {
     paletteSearch.value = '';
     renderPaletteItems();
     paletteDialog.showModal();
+    if (palettePos) {
+      paletteDialog.style.left = `${palettePos.left}px`;
+      paletteDialog.style.top = `${palettePos.top}px`;
+      paletteDialog.style.margin = '0';
+    }
     paletteSearch.focus();
   }
 };
+/* node:coverage enable */
 
 // --- Init ---
 
@@ -294,5 +343,5 @@ register('ctrl-p', togglePalette);
 
 // Exported for unit tests only — not used in browser context.
 if (typeof module !== 'undefined') {
-  module.exports = { filterCommands, getNextIndex };
+  module.exports = { filterCommands, getNextIndex, parseShortcut };
 }

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -18,10 +18,12 @@ const XPATH_MODEL = '//button['
 
 // --- Utilities ---
 
+/* node:coverage ignore next 3 */
 const findByXPath = (xpath) => document.evaluate(
   xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null,
 ).singleNodeValue;
 
+/* node:coverage ignore next 7 */
 const clickOrWarn = (el, name) => {
   if (el) {
     el.click();
@@ -33,6 +35,7 @@ const clickOrWarn = (el, name) => {
 
 // --- Actions ---
 
+/* node:coverage ignore next 5 */
 const clickMic = () => {
   const el = document.querySelector('button[aria-label*="voice" i]')
     ?? document.querySelector('button[aria-label*="microphone" i]')
@@ -40,18 +43,21 @@ const clickMic = () => {
   clickOrWarn(el, 'microphone');
 };
 
+/* node:coverage ignore next 4 */
 const clickModelSelector = () => {
   const el = document.querySelector('button[aria-label*="model" i]')
     ?? findByXPath(XPATH_MODEL);
   clickOrWarn(el, 'model selector');
 };
 
+/* node:coverage ignore next 4 */
 const clickModeToggle = () => {
   const el = findByXPath(XPATH_MODE)
     ?? document.querySelector('button[aria-haspopup="menu"]');
   clickOrWarn(el, 'mode toggle');
 };
 
+/* node:coverage ignore next 6 */
 const clickFileAttach = () => {
   const el = document.querySelector('button[aria-label*="attach" i]')
     ?? document.querySelector('button[aria-label*="file" i]')
@@ -76,6 +82,16 @@ const NATIVE_SHORTCUTS = [
   { label: 'New line in message', shortcut: 'Shift+Enter' },
 ];
 
+// Pure: returns COMMANDS entries whose label contains query (case-insensitive).
+const filterCommands = (query) => COMMANDS.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()));
+
+// Pure: next arrow-key index with wrapping. direction: 1 (down) or -1 (up).
+const getNextIndex = (current, total, direction) => {
+  if (total === 0) return -1;
+  return (current + direction + total) % total;
+};
+
+/* node:coverage ignore next 3 */
 let paletteDialog = null;
 let paletteSearch = null;
 let paletteList = null;
@@ -153,22 +169,25 @@ GM.addStyle(`
   }
 `);
 
+/* node:coverage ignore next 5 */
 const setSelected = (items, idx) => {
   for (const item of items) item.removeAttribute('aria-selected');
   items[idx]?.setAttribute('aria-selected', 'true');
   items[idx]?.scrollIntoView({ block: 'nearest' });
 };
 
+/* node:coverage ignore next 4 */
 const makeCommandClickHandler = (cmd) => () => {
   paletteDialog.close();
   cmd.action();
 };
 
+/* node:coverage disable */
 const renderPaletteItems = () => {
   const query = paletteSearch.value.toLowerCase();
   paletteList.innerHTML = '';
 
-  const filtered = COMMANDS.filter((c) => c.label.toLowerCase().includes(query));
+  const filtered = filterCommands(query);
   const filteredNative = query ? [] : NATIVE_SHORTCUTS;
 
   if (filtered.length) {
@@ -238,10 +257,10 @@ const injectPalette = () => {
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setSelected(items, selectedIdx < items.length - 1 ? selectedIdx + 1 : 0);
+      setSelected(items, getNextIndex(selectedIdx, items.length, 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setSelected(items, selectedIdx > 0 ? selectedIdx - 1 : items.length - 1);
+      setSelected(items, getNextIndex(selectedIdx, items.length, -1));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       items[selectedIdx]?.click();
@@ -266,8 +285,11 @@ const togglePalette = () => {
   }
 };
 
+/* node:coverage enable */
+
 // --- Init ---
 
+/* node:coverage disable */
 injectPalette();
 
 register('ctrl-d', clickMic);
@@ -275,3 +297,9 @@ register('ctrl-shift-i', clickModelSelector);
 register('ctrl-shift-m', clickModeToggle);
 register('ctrl-u', clickFileAttach);
 register('ctrl-shift-p', togglePalette);
+/* node:coverage enable */
+
+// Exported for unit tests only — not used in browser context.
+if (typeof module !== 'undefined') {
+  module.exports = { filterCommands, getNextIndex };
+}

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -38,6 +38,7 @@ const clickOrWarn = (el, name) => {
 /* node:coverage ignore next 5 */
 const clickMic = () => {
   const el = document.querySelector('button[aria-label="Stop dictation"]')
+    ?? document.querySelector('button[aria-label="Finish dictation"]')
     ?? document.querySelector('button[aria-label="Press and hold to record"]');
   clickOrWarn(el, 'microphone');
 };
@@ -49,20 +50,16 @@ const clickModelSelector = () => {
   clickOrWarn(el, 'model selector');
 };
 
-/* node:coverage ignore next 4 */
+/* node:coverage ignore next 3 */
 const clickModeToggle = () => {
-  const el = findByXPath(XPATH_MODE)
-    ?? document.querySelector('button[aria-haspopup="menu"]');
-  clickOrWarn(el, 'mode toggle');
+  clickOrWarn(findByXPath(XPATH_MODE), 'mode toggle');
 };
 
-/* node:coverage ignore next 6 */
+/* node:coverage ignore next 5 */
 const clickFileAttach = () => {
-  const el = document.querySelector('button[aria-label*="attach" i]')
-    ?? document.querySelector('button[aria-label*="file" i]')
-    ?? document.querySelector('button[aria-label*="upload" i]')
-    ?? document.querySelector('input[type="file"]');
-  clickOrWarn(el, 'file attach');
+  document.body.dispatchEvent(new KeyboardEvent('keydown', {
+    ctrlKey: true, key: 'u', bubbles: true, cancelable: true,
+  }));
 };
 
 // --- Command palette ---

--- a/greasemonkey/claude.claude-desktop-shortcuts.user.js
+++ b/greasemonkey/claude.claude-desktop-shortcuts.user.js
@@ -66,7 +66,7 @@ const clickModeToggle = () => {
 
 /* node:coverage ignore next 5 */
 const clickFileAttach = () => {
-  document.body.dispatchEvent(new KeyboardEvent('keydown', {
+  document.dispatchEvent(new KeyboardEvent('keydown', {
     ctrlKey: true, key: 'u', bubbles: true, cancelable: true,
   }));
 };
@@ -211,12 +211,13 @@ const makeCommandClickHandler = (cmd) => () => {
   setTimeout(cmd.action, 0);
 };
 
-// Dispatches a keyboard event to document.body without closing the palette —
-// callers are responsible for closing first via makeCommandClickHandler.
+// Dispatches a keyboard event to document (not body) so SPA shortcut handlers
+// registered at the document level receive it regardless of capture/bubble phase.
+// Callers are responsible for closing the palette first via makeCommandClickHandler.
 /* node:coverage ignore next 4 */
 const dispatchShortcut = (str) => {
   const opts = parseShortcut(str);
-  document.body.dispatchEvent(new KeyboardEvent('keydown', { ...opts, bubbles: true, cancelable: true }));
+  document.dispatchEvent(new KeyboardEvent('keydown', { ...opts, bubbles: true, cancelable: true }));
 };
 
 // Must be defined before renderPaletteItems which iterates over it.
@@ -358,7 +359,12 @@ const injectPalette = () => {
     const offsetY = e.clientY - rect.top;
 
     const onMove = (ev) => {
-      palettePos = { left: ev.clientX - offsetX, top: ev.clientY - offsetY };
+      const maxLeft = window.innerWidth - paletteDialog.offsetWidth;
+      const maxTop = window.innerHeight - paletteDialog.offsetHeight;
+      palettePos = {
+        left: Math.max(0, Math.min(ev.clientX - offsetX, maxLeft)),
+        top: Math.max(0, Math.min(ev.clientY - offsetY, maxTop)),
+      };
       paletteDialog.style.left = `${palettePos.left}px`;
       paletteDialog.style.top = `${palettePos.top}px`;
     };

--- a/greasemonkey/youtube.clear-playlist.user.js
+++ b/greasemonkey/youtube.clear-playlist.user.js
@@ -1,4 +1,3 @@
-/* global GM */
 // ==UserScript==
 // @name        Clear Youtube playlists
 // @namespace   ipwnponies

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,64 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.24.0",
         "husky": "^9.1.7",
+        "jsdom": "^29.1.1",
         "lint-staged": "^17.0.5",
         "prettier-eslint": "^12.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -123,6 +175,159 @@
         "node": ">=4"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.3.tgz",
+      "integrity": "sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -141,6 +346,24 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -497,6 +720,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -723,6 +956,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -739,6 +1000,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -796,6 +1064,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -1563,6 +1844,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -1790,6 +2084,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -1902,6 +2203,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2238,6 +2590,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -2405,6 +2764,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2536,10 +2908,11 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2667,6 +3040,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
@@ -2745,6 +3131,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -2888,6 +3284,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -2940,6 +3343,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -3041,6 +3490,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3100,6 +3559,54 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -3245,6 +3752,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3270,6 +3794,44 @@
     }
   },
   "dependencies": {
+    "@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true
+    },
+    "@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -3354,6 +3916,58 @@
         }
       }
     },
+    "@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "requires": {
+        "css-tree": "^3.0.0"
+      }
+    },
+    "@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true
+    },
+    "@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-color-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.3.tgz",
+      "integrity": "sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==",
+      "dev": true,
+      "requires": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      }
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -3370,6 +3984,13 @@
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -3608,6 +4229,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "requires": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3759,6 +4389,26 @@
         "which": "^2.0.1"
       }
     },
+    "css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "requires": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      }
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3767,6 +4417,12 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -3813,6 +4469,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true
     },
     "environment": {
       "version": "1.1.0",
@@ -4393,6 +5055,15 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.6.0"
+      }
+    },
     "husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -4544,6 +5215,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -4623,6 +5300,43 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+          "dev": true
+        }
       }
     },
     "json-schema-traverse": {
@@ -4856,6 +5570,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
+    },
     "mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -4976,6 +5696,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "requires": {
+        "entities": "^8.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5075,9 +5804,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -5162,6 +5891,15 @@
         "is-regex": "^1.1.4"
       }
     },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
     "semver": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
@@ -5213,6 +5951,12 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
+    },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -5314,6 +6058,12 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -5358,6 +6108,39 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
       "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
       "dev": true
+    },
+    "tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "requires": {
+        "tldts-core": "^7.4.2"
+      }
+    },
+    "tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "requires": {
+        "tldts": "^7.0.5"
+      }
+    },
+    "tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.3.1"
+      }
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -5430,6 +6213,12 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5476,6 +6265,38 @@
             "eslint-visitor-keys": "^1.1.0"
           }
         }
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       }
     },
     "which": {
@@ -5568,6 +6389,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test 'tests/*.test.js'",
+    "test:coverage": "node --experimental-test-coverage --test 'tests/*.test.js'",
     "lint": "eslint greasemonkey/",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.24.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "^17.0.5",
     "prettier-eslint": "^12.0.0"
   },

--- a/tests/claude.claude-desktop-shortcuts.test.js
+++ b/tests/claude.claude-desktop-shortcuts.test.js
@@ -86,6 +86,14 @@ test('getNextIndex — up wraps from first to last', () => {
   assert.equal(getNextIndex(0, 4, -1), 3);
 });
 
+test('getNextIndex — ArrowDown with no selection (-1) returns first item', () => {
+  assert.equal(getNextIndex(-1, 4, 1), 0);
+});
+
+test('getNextIndex — ArrowUp with no selection (-1) returns last item', () => {
+  assert.equal(getNextIndex(-1, 4, -1), 3);
+});
+
 test('getNextIndex — returns -1 when list is empty', () => {
   assert.equal(getNextIndex(0, 0, 1), -1);
   assert.equal(getNextIndex(0, 0, -1), -1);

--- a/tests/claude.claude-desktop-shortcuts.test.js
+++ b/tests/claude.claude-desktop-shortcuts.test.js
@@ -36,9 +36,10 @@ const loadUserscript = (overrides = {}) => {
 
 let filterCommands;
 let getNextIndex;
+let parseShortcut;
 
 test('load script and export pure functions', () => {
-  ({ filterCommands, getNextIndex } = loadUserscript());
+  ({ filterCommands, getNextIndex, parseShortcut } = loadUserscript());
   assert.equal(typeof filterCommands, 'function');
   assert.equal(typeof getNextIndex, 'function');
 });
@@ -93,4 +94,34 @@ test('getNextIndex — returns -1 when list is empty', () => {
 test('getNextIndex — single item always returns 0', () => {
   assert.equal(getNextIndex(0, 1, 1), 0);
   assert.equal(getNextIndex(0, 1, -1), 0);
+});
+
+test('parseShortcut — single key', () => {
+  const r = parseShortcut('Enter');
+  assert.equal(r.key, 'Enter');
+  assert.equal(r.ctrlKey, false);
+  assert.equal(r.shiftKey, false);
+  assert.equal(r.altKey, false);
+  assert.equal(r.metaKey, false);
+});
+
+test('parseShortcut — Ctrl+K lowercases single char key', () => {
+  const r = parseShortcut('Ctrl+K');
+  assert.equal(r.key, 'k');
+  assert.equal(r.ctrlKey, true);
+  assert.equal(r.shiftKey, false);
+});
+
+test('parseShortcut — Ctrl+Shift+O', () => {
+  const r = parseShortcut('Ctrl+Shift+O');
+  assert.equal(r.key, 'o');
+  assert.equal(r.ctrlKey, true);
+  assert.equal(r.shiftKey, true);
+});
+
+test('parseShortcut — Shift+Enter preserves multi-char key', () => {
+  const r = parseShortcut('Shift+Enter');
+  assert.equal(r.key, 'Enter');
+  assert.equal(r.shiftKey, true);
+  assert.equal(r.ctrlKey, false);
 });

--- a/tests/claude.claude-desktop-shortcuts.test.js
+++ b/tests/claude.claude-desktop-shortcuts.test.js
@@ -1,0 +1,96 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const makeMockElement = () => ({
+  id: '', type: '', placeholder: '', autocomplete: '', value: '', open: false,
+  setAttribute() {}, removeAttribute() {}, getAttribute() { return null; },
+  appendChild() {}, addEventListener() {}, querySelector() { return null; },
+  querySelectorAll() { return []; }, scrollIntoView() {}, click() {}, close() {},
+  showModal() {},
+});
+
+const loadUserscript = (overrides = {}) => {
+  const filePath = path.join(__dirname, '..', 'greasemonkey', 'claude.claude-desktop-shortcuts.user.js');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    console: { warn() {} },
+    document: {
+      querySelector: () => null,
+      createElement: () => makeMockElement(),
+      body: { appendChild() {} },
+      evaluate: () => ({ singleNodeValue: null }),
+    },
+    VM: { shortcut: { register() {} } },
+    GM: { addStyle() {} },
+    XPathResult: { FIRST_ORDERED_NODE_TYPE: 0 },
+    ...overrides,
+  };
+  vm.runInNewContext(source, sandbox, { filename: 'claude.claude-desktop-shortcuts.user.js' });
+  return sandbox.module.exports;
+};
+
+let filterCommands;
+let getNextIndex;
+
+test('load script and export pure functions', () => {
+  ({ filterCommands, getNextIndex } = loadUserscript());
+  assert.equal(typeof filterCommands, 'function');
+  assert.equal(typeof getNextIndex, 'function');
+});
+
+test('filterCommands — empty query returns all commands', () => {
+  const result = filterCommands('');
+  assert.ok(result.length > 0);
+  assert.ok(result.every((c) => 'label' in c && 'shortcut' in c && 'action' in c));
+});
+
+test('filterCommands — matches substring case-insensitively', () => {
+  const lower = filterCommands('mic');
+  const upper = filterCommands('MIC');
+  assert.ok(lower.length > 0);
+  assert.deepEqual(lower, upper);
+  assert.ok(lower.every((c) => c.label.toLowerCase().includes('mic')));
+});
+
+test('filterCommands — returns empty array when no match', () => {
+  const result = filterCommands('zzznomatch');
+  assert.equal(result.length, 0);
+});
+
+test('filterCommands — does not mutate COMMANDS array', () => {
+  const before = filterCommands('').length;
+  filterCommands('zzznomatch');
+  const after = filterCommands('').length;
+  assert.equal(before, after);
+});
+
+test('getNextIndex — down from middle', () => {
+  assert.equal(getNextIndex(1, 4, 1), 2);
+});
+
+test('getNextIndex — down wraps from last to first', () => {
+  assert.equal(getNextIndex(3, 4, 1), 0);
+});
+
+test('getNextIndex — up from middle', () => {
+  assert.equal(getNextIndex(2, 4, -1), 1);
+});
+
+test('getNextIndex — up wraps from first to last', () => {
+  assert.equal(getNextIndex(0, 4, -1), 3);
+});
+
+test('getNextIndex — returns -1 when list is empty', () => {
+  assert.equal(getNextIndex(0, 0, 1), -1);
+  assert.equal(getNextIndex(0, 0, -1), -1);
+});
+
+test('getNextIndex — single item always returns 0', () => {
+  assert.equal(getNextIndex(0, 1, 1), 0);
+  assert.equal(getNextIndex(0, 1, -1), 0);
+});

--- a/tests/claude.claude-desktop-shortcuts.test.js
+++ b/tests/claude.claude-desktop-shortcuts.test.js
@@ -46,7 +46,7 @@ test('load script and export pure functions', () => {
 test('filterCommands — empty query returns all commands', () => {
   const result = filterCommands('');
   assert.ok(result.length > 0);
-  assert.ok(result.every((c) => 'label' in c && 'shortcut' in c && 'action' in c));
+  assert.ok(result.every((c) => 'label' in c && 'action' in c));
 });
 
 test('filterCommands — matches substring case-insensitively', () => {


### PR DESCRIPTION
## Summary

Single SPA-aware userscript (`greasemonkey/claude.claude-desktop-shortcuts.user.js`) for `https://claude.ai/*` that adds keyboard shortcuts and a searchable command palette. Works across both Claude Code (`/code/*`) and Claude Chat (`/chat/*`) in the same tab session — no re-init on SPA navigation.

## Hotkeys

| Shortcut | Action | Pages |
|---|---|---|
| `Ctrl+D` | Toggle microphone | Both |
| `Ctrl+P` | Open command palette | Both |

## Command Palette

All other actions are palette-only (no dedicated hotkey). Palette opens via `Ctrl+P`, supports real-time search, arrow-key navigation, Enter to execute, Escape to close. Draggable via title bar; position remembered for the tab session and clamped to viewport bounds.

### Script commands

| Command | Code | Chat |
|---|---|---|
| Toggle microphone | DOM click (full pointer event sequence for press-and-hold) | Same |
| Open model selector | DOM click `button[aria-haspopup="menu"]` + model name text | Same |
| Toggle mode (Plan/Accept/Auto) | DOM click `button[aria-haspopup="menu"]` + mode text | Toast: unavailable |
| Attach file | `Ctrl+U` keyboard dispatch to `document` | Same |

### Native shortcuts (reference + actionable)

`Ctrl+K`, `Ctrl+Shift+O`, `Enter`, `Shift+Enter` — dispatched to `document` so SPA handlers receive them.

## Implementation notes

- **Selector strategy**: `aria-haspopup="menu"` + text content regex for mode/model dropdowns — avoids generated class names, stable across React re-renders. Sidebar nav items lack `aria-haspopup` so they don't match.
- **Mic**: dispatches `mouseenter → pointerdown → mousedown → pointerup → mouseup → click` sequence for the "Press and hold to record" button; plain `.click()` for stop buttons.
- **Enter key containment**: palette keydown handler calls `e.stopPropagation()` and defers `cmd.action` via `setTimeout(0)` to prevent the Enter keydown from leaking into any native palette opened by the action (e.g. Ctrl+K).
- **Keyboard dispatch**: targets `document` (not `document.body`) so capture-phase and bubble-phase listeners at the document level both receive the event.

## Files changed

- `greasemonkey/claude.claude-desktop-shortcuts.user.js` — new script
- `.eslintrc.yml` — added `GM` global (used by new script; also cleaned up redundant inline `/* global GM */` comment in youtube script)
- `tests/claude.claude-desktop-shortcuts.test.js` — unit tests for pure functions: `filterCommands`, `getNextIndex`, `parseShortcut`
- `package.json` — added `test:coverage` script, `jsdom` dev dependency

https://claude.ai/code/session_01Gtc41FwGLDz8rhk6BdXfTR