### PR TITLE
Add Greasemonkey script to open neetcode practice list in same tab

### DIFF
--- a/greasemonkey/neetcode.practice-list-same-tab.user.js
+++ b/greasemonkey/neetcode.practice-list-same-tab.user.js
@@ -1,0 +1,31 @@
+// ==UserScript==
+// @name        Open practice list in same tab - neetcode.io
+// @namespace   ipwnponies
+// @match       https://neetcode.io/*
+// @grant       GM.registerMenuCommand
+// @version     1.0.0
+// @require     https://cdn.jsdelivr.net/npm/@violentmonkey/dom@2
+// @description Add a menu command for the practice list, and fix the "Open List" button to navigate same-tab.
+// ==/UserScript==
+
+function goToPractice() {
+  window.location.assign('/practice');
+}
+
+GM.registerMenuCommand('Go to practice list', goToPractice);
+
+VM.observe(document.body, () => {
+  const openListBtn = document.querySelector('[data-tooltip="Open List"]');
+  if (openListBtn && !openListBtn.dataset.practiceListPatched) {
+    openListBtn.dataset.practiceListPatched = 'true';
+    openListBtn.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        goToPractice();
+      },
+      { capture: true },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
Add a new Greasemonkey userscript that improves navigation on neetcode.io by providing a menu command to access the practice list and fixing the "Open List" button to navigate within the same tab instead of opening a new one.

## Key Changes
- Created new userscript `neetcode.practice-list-same-tab.user.js` for neetcode.io
- Added a menu command "Go to practice list" accessible via the userscript manager
- Patched the "Open List" button to use `window.location.assign()` for same-tab navigation instead of the default behavior
- Implemented DOM observation to dynamically patch the button when it appears on the page, preventing duplicate event listeners

## Implementation Details
- Uses Violentmonkey's `VM.observe()` to monitor DOM changes and apply patches to the "Open List" button
- Includes a guard (`data-practiceListPatched` attribute) to ensure the button is only patched once
- Event listener uses capture phase with `preventDefault()` and `stopImmediatePropagation()` to override the original button behavior

https://claude.ai/code/session_012dNDT9vgZ5XDSV6dzks9Y2