### PR TITLE
Add LinkedIn job posting to Markdown converter userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Scripts that remove paste/copy restrictions on sites that block them for no good
 | `github.approve-shortcut.user.js` | github.com | Approve PR with keyboard |
 | `github.edit-shortcut.user.js` | github.com | Edit issue/comment with keyboard |
 | `google-photos.keybinding-options.user.js` | photos.google.com | Keyboard navigation for photo options |
+| `linkedin.copy-to-markdown.user.js` | linkedin.com | Copy a job posting to the clipboard as markdown (Alt+Shift+C) |
 | `trakt.search-rotten-tomatoes.user.js` | trakt.tv | Search current title on Rotten Tomatoes |
 | `youtube.show-transcript-hotkey.user.js` | youtube.com | Open transcript panel |
 

--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -1,0 +1,220 @@
+// ==UserScript==
+// @name         Copy to Markdown - linkedin.com
+// @namespace    ipwnponies
+// @icon         data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8c3R5bGU+CiAgICAuZmF2aWNvbi1iYWNrZ3JvdW5kIHsgZmlsbDogIzBhNjZjMjsgfQogICAgLmZhdmljb24tdGV4dCB7IGZpbGw6ICNmZmY7IH0KICA8L3N0eWxlPgogIDxwYXRoIGNsYXNzPSJmYXZpY29uLWJhY2tncm91bmQiIGQ9Ik01NS45Miw0SDguMDhBNC4wOCw0LjA4LDAsMCwwLDQsOC4wOFY1NS45MkE0LjA4LDQuMDgsMCwwLDAsOC4wOCw2MEg1NS45MkE0LjA4LDQuMDgsMCwwLDAsNjAsNTUuOTJWOC4wOEE0LjA4LDQuMDgsMCwwLDAsNTUuOTIsNFpNMjAsNTJIMTJWMjVoOFpNMTYsMjAuN2E0LjcsNC43LDAsMCwxLDAtOS40aDBhNC43LDQuNywwLDAsMSwwLDkuNFpNNTIsNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NloiLz4KICA8cGF0aCBjbGFzcz0iZmF2aWNvbi10ZXh0IiBkPSJNNTIsMzUuNzZWNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NlpNMTYsMTEuM0E0LjcsNC43LDAsMSwwLDIwLjcsMTYsNC42OSw0LjY5LDAsMCwwLDE2LDExLjNaTTEyLDUyaDhWMjVIMTJaIiAvPgo8L3N2Zz4=
+// @version      1.0.0
+// @description  Add hotkey/menu command to copy a LinkedIn job posting to the clipboard as markdown
+// @match        https://www.linkedin.com/jobs/view/*
+// @require      https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js
+// @require      https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
+// @grant        GM.registerMenuCommand
+// @grant        GM.setClipboard
+// ==/UserScript==
+
+/* global TurndownService */
+
+const DEBUG = true; // set false to silence console output
+const PREFIX = '[li2md]';
+
+function dlog(...args) {
+  if (DEBUG) console.log(PREFIX, ...args);
+}
+
+function dwarn(...args) {
+  if (DEBUG) console.warn(PREFIX, ...args);
+}
+
+function derror(...args) {
+  console.error(PREFIX, ...args);
+}
+
+// Splits "<job title> | <company> | LinkedIn" into its parts. Used as the
+// fallback when the header block can't be located in the DOM.
+function parseDocumentTitle(title) {
+  const parts = (title || '')
+    .split('|')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts[parts.length - 1] === 'LinkedIn') parts.pop();
+  if (!parts.length) return { jobTitle: '', company: '' };
+  const company = parts.length > 1 ? parts.pop() : '';
+  return { jobTitle: parts.join(' | '), company };
+}
+
+// LinkedIn's <main> holds several sections; only the primary-content one is the
+// posting. The others are premium upsell. aria-label is English-only, hence the
+// <main> fallback.
+function findRoot(doc) {
+  return doc.querySelector('section[aria-label="Primary content"]') || doc.querySelector('main');
+}
+
+const ABOUT_THE_JOB_KEY = 'JobDetails_AboutTheJob_';
+
+// The header has no componentkey. It sits as the sibling immediately before the
+// wrapper that holds every tagged content slot.
+function findHeaderBlock(root) {
+  const aboutJob = root.querySelector(`[componentkey^="${ABOUT_THE_JOB_KEY}"]`);
+  return aboutJob?.parentElement?.previousElementSibling ?? null;
+}
+
+// Allow-list, in the order they should appear in the output. Anything not named
+// here is excluded by construction - LinkedIn adds upsell slots more often than
+// content slots, so an unknown slot should default to excluded.
+const SECTION_KEYS = [
+  ABOUT_THE_JOB_KEY,
+  'JobDetails_AboutTheCompany_',
+  'JobDetailsPeopleWhoCanHelpSlot_',
+  'JobDetailsSimilarJobsSlot_',
+];
+
+function collectSections(root) {
+  return SECTION_KEYS.map((key) => root.querySelector(`[componentkey^="${key}"]`)).filter(
+    (el) => el && el.textContent.trim(),
+  );
+}
+
+// The toggle renders as a bare button with no aria-label and hashed classes, so
+// its text is the only stable hook. Anchored to avoid matching "More jobs".
+const TRUNCATION_TOGGLE = /^(…\s*more|see more)$/i;
+
+function expandTruncated(root) {
+  const toggles = [...root.querySelectorAll('button')].filter((b) => TRUNCATION_TOGGLE.test(b.textContent.trim()));
+  toggles.forEach((b) => b.click());
+  return toggles.length;
+}
+
+function extractJobId(root, url) {
+  const slot = root?.querySelector(`[componentkey^="${ABOUT_THE_JOB_KEY}"]`);
+  const fromKey = slot?.getAttribute('componentkey').slice(ABOUT_THE_JOB_KEY.length);
+  if (fromKey) return fromKey;
+  const match = /\/jobs\/view\/(\d+)/.exec(url || '');
+  return match ? match[1] : '';
+}
+
+// Content slots carry their own <h2>, which Turndown renders as "## ...", so only
+// the header - which has no heading element - gets a synthetic one.
+function buildMarkdown(doc, root, td, url) {
+  const { jobTitle, company } = parseDocumentTitle(doc.title);
+  const heading = [jobTitle, company].filter(Boolean).join(' — ');
+  const parts = [];
+
+  if (heading) parts.push(`# ${heading}`);
+
+  const header = findHeaderBlock(root);
+  if (header) {
+    try {
+      parts.push(td.turndown(header.innerHTML));
+    } catch (e) {
+      derror('header block failed to convert', e);
+    }
+  } else {
+    dwarn('No header block found - falling back to the document title alone');
+  }
+
+  const sections = collectSections(root);
+  if (!sections.length) dwarn('No content sections found - check the componentkey prefixes in SECTION_KEYS');
+
+  // Per-section isolation (header included above): LinkedIn's markup drifts, and
+  // one block that breaks Turndown should cost that block, not the whole copy.
+  // The failure is reported, never swallowed.
+  sections.forEach((el) => {
+    try {
+      parts.push(td.turndown(el.innerHTML));
+    } catch (e) {
+      derror(`section ${el.getAttribute('componentkey')} failed to convert`, e);
+    }
+  });
+
+  const jobId = extractJobId(root, url);
+  parts.push(jobId ? `_Source: ${url} — job ID ${jobId}_` : `_Source: ${url}_`);
+
+  return parts.filter(Boolean).join('\n\n').trim();
+}
+
+function buildTurndownService() {
+  if (typeof TurndownService === 'undefined') {
+    derror('TurndownService is undefined - the @require from jsdelivr did not load (check the network tab)');
+    return null;
+  }
+
+  const td = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+  });
+
+  // Apply, Save, Follow and the truncation toggles are interactive chrome, not
+  // content. They are clicked before this runs, so removing them is safe.
+  td.remove(['script', 'style', 'svg', 'button', 'iframe', 'noscript', 'input', 'label']);
+
+  return td;
+}
+
+function showToast(msg) {
+  let toast = document.getElementById('li2md-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'li2md-toast';
+    toast.style.cssText = [
+      'position:fixed',
+      'top:16px',
+      'right:16px',
+      'z-index:999999',
+      'background:#222',
+      'color:#fff',
+      'padding:8px 14px',
+      'border-radius:6px',
+      'font:14px sans-serif',
+      'opacity:0',
+      'transition:opacity .2s',
+    ].join(';');
+    document.body.appendChild(toast);
+  }
+  toast.textContent = msg;
+  toast.style.opacity = '1';
+  clearTimeout(toast.hideTimer);
+  toast.hideTimer = setTimeout(() => {
+    toast.style.opacity = '0';
+  }, 1800);
+}
+
+async function copyMarkdownToClipboard() {
+  try {
+    const root = findRoot(document);
+    if (!root) {
+      derror('No extraction root - neither section[aria-label="Primary content"] nor <main> matched');
+      showToast('No job content found (see console)');
+      return;
+    }
+
+    const expanded = expandTruncated(root);
+    dlog('expanded truncation toggles:', expanded);
+    // Let the click-driven re-render land before reading the DOM.
+    if (expanded) await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const td = buildTurndownService();
+    if (!td) {
+      showToast('Turndown failed to load (see console)');
+      return;
+    }
+
+    const md = buildMarkdown(document, root, td, window.location.href);
+    // GM.setClipboard is extension-privileged and needs no page-level user
+    // activation, unlike navigator.clipboard - required for the menu command path,
+    // which Firefox does not treat as a user gesture on the page.
+    GM.setClipboard(md);
+    dlog('copied markdown length:', md.length);
+    showToast(`Copied (${md.length} chars)`);
+  } catch (e) {
+    // Last-resort net: every known failure mode above already has its own toast,
+    // so reaching here means something unexpected broke. Surface it instead of
+    // letting it become a silent unhandled rejection.
+    derror('copy failed unexpectedly', e);
+    showToast('Copy failed (see console)');
+  }
+}
+
+VM.shortcut.register('alt-shift-c', copyMarkdownToClipboard);
+
+// Menu command as a discoverable fallback when the hotkey isn't bound or known.
+GM.registerMenuCommand('Copy to Markdown', copyMarkdownToClipboard);

--- a/tests/fixtures/linkedin-job-view.html
+++ b/tests/fixtures/linkedin-job-view.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html>
+<head><title>Staff Platform Engineer | Acme Corp | LinkedIn</title></head>
+<body>
+<main>
+<section aria-label="Primary content">
+  <div>
+    <div>
+      Acme Corp
+      Staff Platform Engineer
+      United States · Reposted 2 days ago · Over 100 people clicked apply
+      Promoted by hirer · Responses managed off LinkedIn
+      Remote
+      Full-time
+      <button>Apply</button>
+      <button>Save</button>
+    </div>
+    <div>
+      <div componentkey="JobDetails_ManageJobBanner_1000000001"></div>
+      <div componentkey="InitialStateHowYouFitSlot">
+        Use AI to assess how you fit
+        Get AI-powered advice on this job and more exclusive features with Premium.
+        Reactivate Premium: 50% Off
+      </div>
+      <div componentkey="JobDetailsPeopleWhoCanHelpSlot_1000000001"></div>
+      <div componentkey="JobDetails_AboutTheJob_1000000001">
+        <h2>About the job</h2>
+        <p>
+          What's in it for you? We're growing fast and looking for engineers who want to
+          make a real impact.
+        </p>
+        <p>
+          About the team &amp; opportunity: our platform team builds the self-service
+          infrastructure that lets product engineers ship independently.
+        </p>
+        <p>
+          Why do we need you? We are looking for a Staff Platform Engineer who will bring
+          operational maturity, deep, hands-on subject-matter expertise with Rust and the
+          Nomad scheduler API, and a strong drive to make an impact. You will report to the
+          Head of Platform Engineering and own delivery of our infrastructure roadmap.
+        </p>
+      </div>
+      <div componentkey="JobDetails_JobAlertToggle_1000000001">
+        Set alert for similar jobs
+        Platform Engineer, United States
+        Off
+      </div>
+      <div componentkey="JobDetails_ResumeReview_1000000001"></div>
+      <div componentkey="JobDetails_PremiumApplicantInsights_1000000001"></div>
+      <div componentkey="JobDetails_PremiumCompanyInsights_1000000001">
+        Job search faster with Premium
+        Access company insights like strategic priorities, headcount trends and more.
+        <button>… more</button>
+      </div>
+      <div componentkey="JobDetails_AboutTheCompany_1000000001">
+        <h2>About the company</h2>
+        <div>
+          Acme Corp
+          12,345 followers
+          <button>Follow</button>
+        </div>
+        <div>Software Development • 501-1000 employees • 842 on LinkedIn</div>
+        <div>
+          Acme Corp builds tools that help small businesses run their day-to-day operations
+          more efficiently. Our platform is used by teams across the globe to automate the
+          busywork so they can focus on what matters.
+          <button>… more</button>
+          <span>
+            We are proud of the culture we've built and are always looking for talented
+            people to join us.
+          </span>
+        </div>
+      </div>
+      <div componentkey="JobDetailsSimilarJobsSlot_1000000001">
+        <h2>More jobs</h2>
+        <a href="#">
+          Fictional Corp A
+          Staff Platform Engineer
+          Rivertown, ST (Remote)
+          $210K/yr - $290K/yr • Medical benefit
+          Promoted · Posted 2 hours ago
+        </a>
+        <a href="#">
+          Fictional Corp B
+          Staff Software Engineer, Platform
+          Lakeside, ST (Remote)
+          Promoted · Posted 3 hours ago
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+</body>
+</html>

--- a/tests/linkedin.copy-to-markdown.test.js
+++ b/tests/linkedin.copy-to-markdown.test.js
@@ -1,0 +1,304 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { JSDOM } = require('jsdom');
+
+const exportedFunctions = [
+  'parseDocumentTitle', 'findRoot', 'findHeaderBlock', 'collectSections', 'expandTruncated', 'extractJobId',
+  'buildMarkdown',
+].join(', ');
+
+const loadUserscript = (overrides = {}) => {
+  const filePath = path.join(__dirname, '..', 'greasemonkey', 'linkedin.copy-to-markdown.user.js');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    console: {
+      log() {}, warn() {}, error() {}, group() {}, groupEnd() {},
+    },
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: (cb) => cb(),
+    Promise,
+    window: { location: { href: 'https://www.linkedin.com/jobs/view/1000000001/' } },
+    document: { title: '', querySelector: () => null, body: { appendChild() {} } },
+    VM: { shortcut: { register() {} } },
+    GM: { registerMenuCommand() {}, setClipboard() {} },
+    ...overrides,
+  };
+
+  vm.runInNewContext(`${source}\nmodule.exports = { ${exportedFunctions} };`, sandbox, {
+    filename: 'linkedin.copy-to-markdown.user.js',
+  });
+
+  return sandbox.module.exports;
+};
+
+const fixturePath = path.join(__dirname, 'fixtures', 'linkedin-job-view.html');
+const loadFixtureDocument = () => new JSDOM(fs.readFileSync(fixturePath, 'utf8')).window.document;
+
+const {
+  parseDocumentTitle, findRoot, findHeaderBlock, collectSections, expandTruncated, extractJobId, buildMarkdown,
+} = loadUserscript();
+
+// Values returned from vm.runInNewContext live in a different realm than this
+// file, so plain objects have a different prototype than a host-realm literal.
+// assert.deepEqual (deepStrictEqual) treats that as unequal even when every
+// property matches, so results are spread into a host-realm object first.
+const plain = (obj) => ({ ...obj });
+
+test('parseDocumentTitle — standard LinkedIn job title', () => {
+  assert.deepEqual(plain(parseDocumentTitle('Staff Platform Engineer | Acme Corp | LinkedIn')), {
+    jobTitle: 'Staff Platform Engineer',
+    company: 'Acme Corp',
+  });
+});
+
+test('parseDocumentTitle — no company segment', () => {
+  assert.deepEqual(plain(parseDocumentTitle('Some Job | LinkedIn')), { jobTitle: 'Some Job', company: '' });
+});
+
+test('parseDocumentTitle — pipe inside the job title', () => {
+  assert.deepEqual(plain(parseDocumentTitle('Engineer | Backend | Acme | LinkedIn')), {
+    jobTitle: 'Engineer | Backend',
+    company: 'Acme',
+  });
+});
+
+test('parseDocumentTitle — empty title', () => {
+  assert.deepEqual(plain(parseDocumentTitle('')), { jobTitle: '', company: '' });
+});
+
+test('parseDocumentTitle — undefined title', () => {
+  assert.deepEqual(plain(parseDocumentTitle(undefined)), { jobTitle: '', company: '' });
+});
+
+test('findRoot — prefers the primary content section', () => {
+  const doc = loadFixtureDocument();
+  const root = findRoot(doc);
+  assert.equal(root.tagName, 'SECTION');
+  assert.equal(root.getAttribute('aria-label'), 'Primary content');
+});
+
+test('findRoot — falls back to main when the primary section is absent', () => {
+  const doc = new JSDOM('<main><p>content</p></main>').window.document;
+  assert.equal(findRoot(doc).tagName, 'MAIN');
+});
+
+test('findRoot — returns null when neither is present', () => {
+  const doc = new JSDOM('<div><p>content</p></div>').window.document;
+  assert.equal(findRoot(doc), null);
+});
+
+test('findHeaderBlock — extracts the job header from the fixture', () => {
+  const root = findRoot(loadFixtureDocument());
+  const text = findHeaderBlock(root).textContent.replace(/\s+/g, ' ');
+  assert.match(text, /Staff Platform Engineer/);
+  assert.match(text, /Acme Corp/);
+  assert.match(text, /United States/);
+  assert.match(text, /Reposted 2 days ago/);
+  assert.match(text, /Over 100 people clicked apply/);
+  assert.match(text, /Remote/);
+  assert.match(text, /Full-time/);
+});
+
+test('findHeaderBlock — excludes the job description', () => {
+  const root = findRoot(loadFixtureDocument());
+  assert.doesNotMatch(findHeaderBlock(root).textContent, /About the job/);
+});
+
+test('findHeaderBlock — returns null when the description slot is missing', () => {
+  const root = new JSDOM('<main><div>nothing here</div></main>').window.document.querySelector('main');
+  assert.equal(findHeaderBlock(root), null);
+});
+
+test('collectSections — returns non-empty content slots in document order', () => {
+  const root = findRoot(loadFixtureDocument());
+  const keys = [...collectSections(root).map((el) => el.getAttribute('componentkey'))];
+  assert.deepEqual(keys, [
+    'JobDetails_AboutTheJob_1000000001',
+    'JobDetails_AboutTheCompany_1000000001',
+    'JobDetailsSimilarJobsSlot_1000000001',
+  ]);
+});
+
+test('collectSections — drops slots that render empty', () => {
+  const root = findRoot(loadFixtureDocument());
+  const keys = collectSections(root).map((el) => el.getAttribute('componentkey'));
+  // The hiring-team slot exists in the DOM but has no text on this posting.
+  assert.ok(root.querySelector('[componentkey^="JobDetailsPeopleWhoCanHelpSlot_"]'));
+  assert.ok(!keys.some((k) => k.startsWith('JobDetailsPeopleWhoCanHelpSlot_')));
+});
+
+test('collectSections — excludes premium and furniture slots', () => {
+  const root = findRoot(loadFixtureDocument());
+  const keys = collectSections(root).map((el) => el.getAttribute('componentkey'));
+  const excluded = [
+    'InitialStateHowYouFitSlot',
+    'JobDetails_PremiumApplicantInsights_',
+    'JobDetails_PremiumCompanyInsights_',
+    'JobDetails_ResumeReview_',
+    'JobDetails_ManageJobBanner_',
+    'JobDetails_JobAlertToggle_',
+  ];
+  excluded.forEach((prefix) => {
+    assert.ok(!keys.some((k) => k.startsWith(prefix)), `${prefix} should not be collected`);
+  });
+});
+
+test('collectSections — returns an empty array when no slots are present', () => {
+  const root = new JSDOM('<main><div>nothing</div></main>').window.document.querySelector('main');
+  assert.deepEqual([...collectSections(root)], []);
+});
+
+test('expandTruncated — clicks every truncation toggle in the fixture', () => {
+  const root = findRoot(loadFixtureDocument());
+  const clicked = [];
+  root.querySelectorAll('button').forEach((b) => {
+    b.addEventListener('click', () => clicked.push(b.textContent.trim()));
+  });
+  assert.equal(expandTruncated(root), 2);
+  assert.equal(clicked.length, 2);
+  clicked.forEach((label) => assert.match(label, /more/i));
+});
+
+test('expandTruncated — ignores buttons that merely contain the word more', () => {
+  const doc = new JSDOM(`
+    <main>
+      <button>More jobs</button>
+      <button>Show more results</button>
+      <button>… more</button>
+      <button>See more</button>
+    </main>
+  `).window.document;
+  const root = doc.querySelector('main');
+  const clicked = [];
+  root.querySelectorAll('button').forEach((b) => {
+    b.addEventListener('click', () => clicked.push(b.textContent.trim()));
+  });
+  assert.equal(expandTruncated(root), 2);
+  assert.deepEqual(clicked, ['… more', 'See more']);
+});
+
+test('expandTruncated — returns 0 when there is nothing to expand', () => {
+  const root = new JSDOM('<main><p>text</p></main>').window.document.querySelector('main');
+  assert.equal(expandTruncated(root), 0);
+});
+
+test('extractJobId — reads the id from the componentkey suffix', () => {
+  const root = findRoot(loadFixtureDocument());
+  assert.equal(extractJobId(root, 'https://www.linkedin.com/jobs/view/1000000001/'), '1000000001');
+});
+
+test('extractJobId — falls back to the URL when the slot is missing', () => {
+  const root = new JSDOM('<main></main>').window.document.querySelector('main');
+  assert.equal(extractJobId(root, 'https://www.linkedin.com/jobs/view/1234567890/'), '1234567890');
+});
+
+test('extractJobId — handles a URL with query parameters', () => {
+  const root = new JSDOM('<main></main>').window.document.querySelector('main');
+  assert.equal(extractJobId(root, 'https://www.linkedin.com/jobs/view/999/?refId=abc'), '999');
+});
+
+test('extractJobId — returns an empty string when the id is unknowable', () => {
+  const root = new JSDOM('<main></main>').window.document.querySelector('main');
+  assert.equal(extractJobId(root, 'https://www.linkedin.com/feed/'), '');
+  assert.equal(extractJobId(null, ''), '');
+});
+
+// Turndown loads from a CDN at runtime and is third-party; the fake keeps these
+// tests about which content is selected, not about markdown fidelity.
+const fakeTurndown = {
+  turndown: (html) => html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
+};
+
+const buildFixtureMarkdown = () => {
+  const doc = loadFixtureDocument();
+  const root = findRoot(doc);
+  return buildMarkdown(doc, root, fakeTurndown, 'https://www.linkedin.com/jobs/view/1000000001/');
+};
+
+test('buildMarkdown — opens with a heading built from the document title', () => {
+  assert.ok(buildFixtureMarkdown().startsWith('# Staff Platform Engineer — Acme Corp\n'));
+});
+
+test('buildMarkdown — includes the header details', () => {
+  const md = buildFixtureMarkdown();
+  assert.match(md, /United States/);
+  assert.match(md, /Reposted 2 days ago/);
+  assert.match(md, /Over 100 people clicked apply/);
+  assert.match(md, /Full-time/);
+});
+
+test('buildMarkdown — includes every allow-listed section', () => {
+  const md = buildFixtureMarkdown();
+  assert.match(md, /About the job/);
+  assert.match(md, /Nomad scheduler API/);
+  assert.match(md, /About the company/);
+  assert.match(md, /Software Development . 501-1000 employees/);
+  assert.match(md, /More jobs/);
+  assert.match(md, /\$210K\/yr - \$290K\/yr/);
+});
+
+test('buildMarkdown — excludes premium upsell content', () => {
+  const md = buildFixtureMarkdown();
+  assert.doesNotMatch(md, /Reactivate Premium/);
+  assert.doesNotMatch(md, /Use AI to assess how you fit/);
+  assert.doesNotMatch(md, /Job search faster with Premium/);
+  assert.doesNotMatch(md, /Set alert for similar jobs/);
+});
+
+test('buildMarkdown — ends with a source footer carrying the job id', () => {
+  const md = buildFixtureMarkdown();
+  assert.ok(md.endsWith('_Source: https://www.linkedin.com/jobs/view/1000000001/ — job ID 1000000001_'));
+});
+
+test('buildMarkdown — omits the job id from the footer when unknown', () => {
+  const doc = new JSDOM('<html><head><title>Role | Acme | LinkedIn</title></head><body><main></main></body></html>')
+    .window.document;
+  const md = buildMarkdown(doc, doc.querySelector('main'), fakeTurndown, 'https://www.linkedin.com/feed/');
+  assert.ok(md.endsWith('_Source: https://www.linkedin.com/feed/_'));
+  assert.ok(md.startsWith('# Role — Acme'));
+});
+
+test('buildMarkdown — a section that throws does not lose the other sections', () => {
+  const doc = loadFixtureDocument();
+  const root = findRoot(doc);
+  let call = 0;
+  const flakyTurndown = {
+    turndown: (html) => {
+      call += 1;
+      // Fail on the job description, the second conversion after the header.
+      if (call === 2) throw new Error('turndown exploded');
+      return fakeTurndown.turndown(html);
+    },
+  };
+  const md = buildMarkdown(doc, root, flakyTurndown, 'https://www.linkedin.com/jobs/view/1000000001/');
+  assert.doesNotMatch(md, /Nomad scheduler API/);
+  assert.match(md, /About the company/);
+  assert.match(md, /More jobs/);
+  assert.ok(md.endsWith('_Source: https://www.linkedin.com/jobs/view/1000000001/ — job ID 1000000001_'));
+});
+
+test('buildMarkdown — a header that throws does not lose the sections', () => {
+  const doc = loadFixtureDocument();
+  const root = findRoot(doc);
+  let call = 0;
+  const flakyTurndown = {
+    turndown: (html) => {
+      call += 1;
+      // Fail on the header, the first conversion.
+      if (call === 1) throw new Error('turndown exploded');
+      return fakeTurndown.turndown(html);
+    },
+  };
+  const md = buildMarkdown(doc, root, flakyTurndown, 'https://www.linkedin.com/jobs/view/1000000001/');
+  assert.doesNotMatch(md, /Reposted 2 days ago/);
+  assert.match(md, /Nomad scheduler API/);
+  assert.match(md, /About the company/);
+  assert.match(md, /More jobs/);
+  assert.ok(md.endsWith('_Source: https://www.linkedin.com/jobs/view/1000000001/ — job ID 1000000001_'));
+});


### PR DESCRIPTION
## Summary
Add a new Greasemonkey userscript that converts LinkedIn job postings to Markdown format and copies them to the clipboard. Includes comprehensive test suite with fixtures.

## Key Changes
- **New userscript** (`linkedin.copy-to-markdown.user.js`): Extracts job posting content from LinkedIn job view pages and converts to Markdown
  - Parses document title to extract job title and company name
  - Locates and extracts the primary content section from LinkedIn's DOM
  - Identifies and expands truncated content sections
  - Collects allow-listed content sections (About the Job, About the Company, Similar Jobs) while excluding premium upsell content
  - Converts HTML to Markdown using Turndown library
  - Provides hotkey (Alt+Shift+C) and menu command for easy access
  - Includes error handling and user feedback via toast notifications

- **Comprehensive test suite** (`linkedin.copy-to-markdown.test.js`): Tests all exported functions with 20+ test cases covering:
  - Document title parsing with various formats
  - DOM element selection and fallbacks
  - Content section collection and filtering
  - Truncation toggle detection and expansion
  - Job ID extraction from multiple sources
  - Markdown generation with proper formatting and error isolation
  - Premium content exclusion

- **Test fixture** (`linkedin-job-view.html`): Realistic HTML snapshot of a LinkedIn job posting page for testing

## Notable Implementation Details
- Uses component key prefixes to identify and allow-list specific content sections, making the script resilient to LinkedIn's DOM changes
- Implements per-section error isolation so a single broken section doesn't prevent conversion of the entire posting
- Distinguishes between truncation toggles ("… more", "See more") and other buttons containing "more" text
- Falls back gracefully when header block or job ID cannot be located
- Uses VM.shortcut for hotkey registration and GM.setClipboard for clipboard access (extension-privileged, works without page-level user activation)

https://claude.ai/code/session_01HW15LcANAfoh8WhS5uNTx6