### PR TITLE
Fix Turndown API usage and add content loading wait

### DIFF
--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -100,10 +100,15 @@ function buildMarkdown(doc, root, td, url) {
 
   if (heading) parts.push(`# ${heading}`);
 
+  // Pass elements, not innerHTML strings: given a string, Turndown reparses it
+  // via `new DOMParser()` and locates its wrapper by id. LinkedIn patches
+  // DOMParser.prototype.parseFromString as an XSS sanitizer that strips
+  // unrecognized tags (including Turndown's wrapper), which breaks that path.
+  // Passing the element makes Turndown clone it directly, skipping the reparse.
   const header = findHeaderBlock(root);
   if (header) {
     try {
-      parts.push(td.turndown(header.innerHTML));
+      parts.push(td.turndown(header));
     } catch (e) {
       derror('header block failed to convert', e);
     }
@@ -119,7 +124,7 @@ function buildMarkdown(doc, root, td, url) {
   // The failure is reported, never swallowed.
   sections.forEach((el) => {
     try {
-      parts.push(td.turndown(el.innerHTML));
+      parts.push(td.turndown(el));
     } catch (e) {
       derror(`section ${el.getAttribute('componentkey')} failed to convert`, e);
     }

--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -155,6 +155,27 @@ function buildTurndownService() {
   return td;
 }
 
+// LinkedIn renders the page shell first and fills in the header/content slots
+// from a follow-up fetch, so reading the DOM immediately can catch it before
+// that data lands. Poll briefly rather than assuming it's there on first read.
+function waitForJobContent(root, { timeout = 5000, interval = 150 } = {}) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const check = () => {
+      if (findHeaderBlock(root) || collectSections(root).length) {
+        resolve(true);
+        return;
+      }
+      if (Date.now() - start >= timeout) {
+        resolve(false);
+        return;
+      }
+      setTimeout(check, interval);
+    };
+    check();
+  });
+}
+
 function showToast(msg) {
   let toast = document.getElementById('li2md-toast');
   if (!toast) {
@@ -191,6 +212,9 @@ async function copyMarkdownToClipboard() {
       showToast('No job content found (see console)');
       return;
     }
+
+    const ready = await waitForJobContent(root);
+    if (!ready) dwarn('Job content did not finish loading in time - copying whatever is present');
 
     const expanded = expandTruncated(root);
     dlog('expanded truncation toggles:', expanded);

--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -2,9 +2,10 @@
 // @name         Copy to Markdown - linkedin.com
 // @namespace    ipwnponies
 // @icon         data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8c3R5bGU+CiAgICAuZmF2aWNvbi1iYWNrZ3JvdW5kIHsgZmlsbDogIzBhNjZjMjsgfQogICAgLmZhdmljb24tdGV4dCB7IGZpbGw6ICNmZmY7IH0KICA8L3N0eWxlPgogIDxwYXRoIGNsYXNzPSJmYXZpY29uLWJhY2tncm91bmQiIGQ9Ik01NS45Miw0SDguMDhBNC4wOCw0LjA4LDAsMCwwLDQsOC4wOFY1NS45MkE0LjA4LDQuMDgsMCwwLDAsOC4wOCw2MEg1NS45MkE0LjA4LDQuMDgsMCwwLDAsNjAsNTUuOTJWOC4wOEE0LjA4LDQuMDgsMCwwLDAsNTUuOTIsNFpNMjAsNTJIMTJWMjVoOFpNMTYsMjAuN2E0LjcsNC43LDAsMCwxLDAtOS40aDBhNC43LDQuNywwLDAsMSwwLDkuNFpNNTIsNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NloiLz4KICA8cGF0aCBjbGFzcz0iZmF2aWNvbi10ZXh0IiBkPSJNNTIsMzUuNzZWNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NlpNMTYsMTEuM0E0LjcsNC43LDAsMSwwLDIwLjcsMTYsNC42OSw0LjY5LDAsMCwwLDE2LDExLjNaTTEyLDUyaDhWMjVIMTJaIiAvPgo8L3N2Zz4=
-// @version      1.0.0
+// @version      1.1.1
 // @description  Add hotkey/menu command to copy a LinkedIn job posting to the clipboard as markdown
 // @match        https://www.linkedin.com/jobs/view/*
+// @match        https://www.linkedin.com/comm/jobs/view/*
 // @require      https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js
 // @require      https://cdn.jsdelivr.net/npm/@violentmonkey/shortcut@1
 // @grant        GM.registerMenuCommand

--- a/tests/linkedin.copy-to-markdown.test.js
+++ b/tests/linkedin.copy-to-markdown.test.js
@@ -210,9 +210,10 @@ test('extractJobId — returns an empty string when the id is unknowable', () =>
 });
 
 // Turndown loads from a CDN at runtime and is third-party; the fake keeps these
-// tests about which content is selected, not about markdown fidelity.
+// tests about which content is selected, not about markdown fidelity. buildMarkdown
+// passes elements (not innerHTML strings), matching the real Turndown API.
 const fakeTurndown = {
-  turndown: (html) => html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
+  turndown: (node) => node.innerHTML.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
 };
 
 const buildFixtureMarkdown = () => {
@@ -269,11 +270,11 @@ test('buildMarkdown — a section that throws does not lose the other sections',
   const root = findRoot(doc);
   let call = 0;
   const flakyTurndown = {
-    turndown: (html) => {
+    turndown: (node) => {
       call += 1;
       // Fail on the job description, the second conversion after the header.
       if (call === 2) throw new Error('turndown exploded');
-      return fakeTurndown.turndown(html);
+      return fakeTurndown.turndown(node);
     },
   };
   const md = buildMarkdown(doc, root, flakyTurndown, 'https://www.linkedin.com/jobs/view/1000000001/');
@@ -288,11 +289,11 @@ test('buildMarkdown — a header that throws does not lose the sections', () => 
   const root = findRoot(doc);
   let call = 0;
   const flakyTurndown = {
-    turndown: (html) => {
+    turndown: (node) => {
       call += 1;
       // Fail on the header, the first conversion.
       if (call === 1) throw new Error('turndown exploded');
-      return fakeTurndown.turndown(html);
+      return fakeTurndown.turndown(node);
     },
   };
   const md = buildMarkdown(doc, root, flakyTurndown, 'https://www.linkedin.com/jobs/view/1000000001/');

--- a/tests/linkedin.copy-to-markdown.test.js
+++ b/tests/linkedin.copy-to-markdown.test.js
@@ -7,7 +7,7 @@ const { JSDOM } = require('jsdom');
 
 const exportedFunctions = [
   'parseDocumentTitle', 'findRoot', 'findHeaderBlock', 'collectSections', 'expandTruncated', 'extractJobId',
-  'buildMarkdown',
+  'buildMarkdown', 'waitForJobContent',
 ].join(', ');
 
 const loadUserscript = (overrides = {}) => {
@@ -42,6 +42,7 @@ const loadFixtureDocument = () => new JSDOM(fs.readFileSync(fixturePath, 'utf8')
 
 const {
   parseDocumentTitle, findRoot, findHeaderBlock, collectSections, expandTruncated, extractJobId, buildMarkdown,
+  waitForJobContent,
 } = loadUserscript();
 
 // Values returned from vm.runInNewContext live in a different realm than this
@@ -186,6 +187,32 @@ test('expandTruncated — ignores buttons that merely contain the word more', ()
 test('expandTruncated — returns 0 when there is nothing to expand', () => {
   const root = new JSDOM('<main><p>text</p></main>').window.document.querySelector('main');
   assert.equal(expandTruncated(root), 0);
+});
+
+test('waitForJobContent — resolves true immediately when content is already present', async () => {
+  const root = findRoot(loadFixtureDocument());
+  const result = await waitForJobContent(root, { timeout: 1000, interval: 10 });
+  assert.equal(result, true);
+});
+
+test('waitForJobContent — resolves true once content appears asynchronously', async () => {
+  const doc = new JSDOM('<main></main>').window.document;
+  const root = doc.querySelector('main');
+  setTimeout(() => {
+    const el = doc.createElement('div');
+    el.setAttribute('componentkey', 'JobDetails_AboutTheJob_1');
+    el.textContent = 'About the job';
+    root.appendChild(el);
+  }, 30);
+  const result = await waitForJobContent(root, { timeout: 1000, interval: 10 });
+  assert.equal(result, true);
+});
+
+test('waitForJobContent — resolves false when content never appears within the timeout', async () => {
+  const doc = new JSDOM('<main></main>').window.document;
+  const root = doc.querySelector('main');
+  const result = await waitForJobContent(root, { timeout: 50, interval: 10 });
+  assert.equal(result, false);
 });
 
 test('extractJobId — reads the id from the componentkey suffix', () => {


### PR DESCRIPTION
## Summary
This PR fixes how the userscript passes content to Turndown and adds a polling mechanism to wait for LinkedIn's asynchronous job content to load before processing.

## Key Changes

- **Fixed Turndown API usage**: Changed from passing `innerHTML` strings to passing DOM elements directly. This is necessary because LinkedIn patches `DOMParser.prototype.parseFromString` as an XSS sanitizer that strips unrecognized tags, which breaks Turndown's internal reparsing logic when given strings.

- **Added `waitForJobContent()` function**: Implements polling to wait for job header and section content to appear in the DOM, since LinkedIn renders the page shell first and fills in content asynchronously. Includes configurable timeout (default 5s) and interval (default 150ms).

- **Updated URL matching**: Added support for LinkedIn's `/comm/jobs/view/` URL pattern in addition to the existing `/jobs/view/` pattern.

- **Version bump**: Updated from 1.0.0 to 1.1.1.

- **Enhanced test coverage**: Added three new test cases for `waitForJobContent()` covering immediate resolution, asynchronous content arrival, and timeout scenarios. Updated existing Turndown mock tests to work with the element-based API.

## Implementation Details

The `waitForJobContent()` function polls the DOM by checking if either a header block or sections exist, resolving to `true` when content is found or `false` if the timeout expires. This is called before content processing to ensure LinkedIn's async fetch has completed.

The Turndown API change is critical for compatibility with LinkedIn's DOM security measures—passing elements allows Turndown to clone them directly rather than attempting to reparse HTML strings through the patched `DOMParser`.

https://claude.ai/code/session_012Um8xc9FcqJRPP2Y9SW5Ei