### PR TITLE
fix(userscript): truncate About the company section at first &lt;hr&gt;

### DIFF
--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -2,7 +2,7 @@
 // @name         Copy to Markdown - linkedin.com
 // @namespace    ipwnponies
 // @icon         data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8c3R5bGU+CiAgICAuZmF2aWNvbi1iYWNrZ3JvdW5kIHsgZmlsbDogIzBhNjZjMjsgfQogICAgLmZhdmljb24tdGV4dCB7IGZpbGw6ICNmZmY7IH0KICA8L3N0eWxlPgogIDxwYXRoIGNsYXNzPSJmYXZpY29uLWJhY2tncm91bmQiIGQ9Ik01NS45Miw0SDguMDhBNC4wOCw0LjA4LDAsMCwwLDQsOC4wOFY1NS45MkE0LjA4LDQuMDgsMCwwLDAsOC4wOCw2MEg1NS45MkE0LjA4LDQuMDgsMCwwLDAsNjAsNTUuOTJWOC4wOEE0LjA4LDQuMDgsMCwwLDAsNTUuOTIsNFpNMjAsNTJIMTJWMjVoOFpNMTYsMjAuN2E0LjcsNC43LDAsMCwxLDAtOS40aDBhNC43LDQuNywwLDAsMSwwLDkuNFpNNTIsNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NloiLz4KICA8cGF0aCBjbGFzcz0iZmF2aWNvbi10ZXh0IiBkPSJNNTIsMzUuNzZWNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NlpNMTYsMTEuM0E0LjcsNC43LDAsMSwwLDIwLjcsMTYsNC42OSw0LjY5LDAsMCwwLDE2LDExLjNaTTEyLDUyaDhWMjVIMTJaIiAvPgo8L3N2Zz4=
-// @version      1.1.2
+// @version      1.1.3
 // @description  Add hotkey/menu command to copy a LinkedIn job posting to the clipboard as markdown
 // @match        https://www.linkedin.com/jobs/view/*
 // @match        https://www.linkedin.com/comm/jobs/view/*
@@ -67,10 +67,25 @@ const SECTION_KEYS = [
   'JobDetailsPeopleWhoCanHelpSlot_',
 ];
 
+// LinkedIn appends unrelated feed content (trending posts, videos, "Show more"
+// link) after the real section body, separated by a bare <hr>. Truncate there:
+// everything from the first <hr> onward is chrome, not section content.
+function trimAtFirstHr(el) {
+  const clone = el.cloneNode(true);
+  const hr = clone.querySelector('hr');
+  let node = hr;
+  while (node) {
+    const next = node.nextSibling;
+    node.remove();
+    node = next;
+  }
+  return clone;
+}
+
 function collectSections(root) {
-  return SECTION_KEYS.map((key) => root.querySelector(`[componentkey^="${key}"]`)).filter(
-    (el) => el && el.textContent.trim(),
-  );
+  return SECTION_KEYS.map((key) => root.querySelector(`[componentkey^="${key}"]`))
+    .filter((el) => el && el.textContent.trim())
+    .map(trimAtFirstHr);
 }
 
 // The toggle renders as a bare button with no aria-label and hashed classes, so

--- a/tests/linkedin.copy-to-markdown.test.js
+++ b/tests/linkedin.copy-to-markdown.test.js
@@ -150,6 +150,37 @@ test('collectSections — excludes premium and furniture slots', () => {
   });
 });
 
+test('collectSections — truncates a section at its first <hr>, dropping trailing feed chrome', () => {
+  const doc = new JSDOM(`
+    <main>
+      <div componentkey="JobDetails_AboutTheCompany_1">
+        <p>About the company</p>
+        <p>Real company description</p>
+        <hr>
+        <p>Trending employee content</p>
+        <p>Some unrelated feed post</p>
+      </div>
+    </main>
+  `).window.document;
+  const root = doc.querySelector('main');
+  const [section] = collectSections(root);
+  assert.match(section.textContent, /Real company description/);
+  assert.doesNotMatch(section.textContent, /Trending employee content/);
+  assert.doesNotMatch(section.textContent, /Some unrelated feed post/);
+  assert.equal(section.querySelector('hr'), null);
+});
+
+test('collectSections — leaves a section untouched when it has no <hr>', () => {
+  const doc = new JSDOM(`
+    <main>
+      <div componentkey="JobDetails_AboutTheCompany_1"><p>No hr here</p></div>
+    </main>
+  `).window.document;
+  const root = doc.querySelector('main');
+  const [section] = collectSections(root);
+  assert.match(section.textContent, /No hr here/);
+});
+
 test('collectSections — returns an empty array when no slots are present', () => {
   const root = new JSDOM('<main><div>nothing</div></main>').window.document.querySelector('main');
   assert.deepEqual([...collectSections(root)], []);


### PR DESCRIPTION
## Summary
- `collectSections` copied LinkedIn's `JobDetails_AboutTheCompany_*` block verbatim, pulling in unrelated feed chrome (trending posts, embedded videos, "Show more" link) that sits after a bare `<hr>` following the real company blurb.
- Added `trimAtFirstHr`: clones the section, drops the `<hr>` and everything after it in its parent. No-op when a section has no `<hr>`.
- Bumped `@version` 1.1.2 → 1.1.3.

## Test plan
- [x] `node --test tests/linkedin.copy-to-markdown.test.js` — 35/35 pass, including 2 new regression tests (truncate-at-hr, no-hr no-op)
- [x] `npx eslint` — no new warnings/errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDBDwCH8xoCtwVFoxoVCYa)_