### PR TITLE
fix(userscript): scope expandTruncated to allow-listed content only

### DIFF
--- a/greasemonkey/AGENTS.md
+++ b/greasemonkey/AGENTS.md
@@ -33,6 +33,8 @@ Every script opens with a metadata block inside a `// ==UserScript== ... // ==/U
 
 `@namespace` + `@name` = unique identity. Do not use `@author`. Multiple `@match` lines allowed — use the narrowest pattern that covers target pages.
 
+Bump `@version` (semver) whenever a script's behavior changes — Violentmonkey tracks updates by that field, so a shipped change without a bump won't be picked up by installed users.
+
 Pin `@require` to a major version (`@2`, `@1`) rather than `latest`.
 
 ## GM APIs

--- a/greasemonkey/CLAUDE.md
+++ b/greasemonkey/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/greasemonkey/linkedin.copy-to-markdown.user.js
+++ b/greasemonkey/linkedin.copy-to-markdown.user.js
@@ -2,7 +2,7 @@
 // @name         Copy to Markdown - linkedin.com
 // @namespace    ipwnponies
 // @icon         data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8c3R5bGU+CiAgICAuZmF2aWNvbi1iYWNrZ3JvdW5kIHsgZmlsbDogIzBhNjZjMjsgfQogICAgLmZhdmljb24tdGV4dCB7IGZpbGw6ICNmZmY7IH0KICA8L3N0eWxlPgogIDxwYXRoIGNsYXNzPSJmYXZpY29uLWJhY2tncm91bmQiIGQ9Ik01NS45Miw0SDguMDhBNC4wOCw0LjA4LDAsMCwwLDQsOC4wOFY1NS45MkE0LjA4LDQuMDgsMCwwLDAsOC4wOCw2MEg1NS45MkE0LjA4LDQuMDgsMCwwLDAsNjAsNTUuOTJWOC4wOEE0LjA4LDQuMDgsMCwwLDAsNTUuOTIsNFpNMjAsNTJIMTJWMjVoOFpNMTYsMjAuN2E0LjcsNC43LDAsMCwxLDAtOS40aDBhNC43LDQuNywwLDAsMSwwLDkuNFpNNTIsNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NloiLz4KICA8cGF0aCBjbGFzcz0iZmF2aWNvbi10ZXh0IiBkPSJNNTIsMzUuNzZWNTJINDRWMzcuODFjMC00LjMxLTIuNzMtNi4xMS01LTYuMTFhNS44Miw1LjgyLDAsMCwwLTYsNi4yMVY1MkgyNVYyNWg3LjUzdjMuNzloLjExYy44LTEuNjQsNC40NC00LjM3LDkuMTMtNC4zN1M1MiwyNy41OSw1MiwzNS43NlpNMTYsMTEuM0E0LjcsNC43LDAsMSwwLDIwLjcsMTYsNC42OSw0LjY5LDAsMCwwLDE2LDExLjNaTTEyLDUyaDhWMjVIMTJaIiAvPgo8L3N2Zz4=
-// @version      1.1.3
+// @version      1.1.4
 // @description  Add hotkey/menu command to copy a LinkedIn job posting to the clipboard as markdown
 // @match        https://www.linkedin.com/jobs/view/*
 // @match        https://www.linkedin.com/comm/jobs/view/*
@@ -92,8 +92,44 @@ function collectSections(root) {
 // its text is the only stable hook. Anchored to avoid matching "More jobs".
 const TRUNCATION_TOGGLE = /^(…\s*more|see more)$/i;
 
+// Same scope buildMarkdown ends up keeping (header + allow-listed sections), but
+// untrimmed - callers here need real nodes to click, not the clones trimAtFirstHr
+// hands back. Sections outside this allow-list (premium upsell, etc.) and content
+// past a section's first <hr> (e.g. the "Trending employee content" carousel inside
+// AboutTheCompany) must never be clicked: those buttons often sit inside an <a>
+// wrapping an unrelated feed post, and .click() bubbles into that anchor, causing
+// the page to navigate away.
+function truncationScope(root) {
+  const header = findHeaderBlock(root);
+  const sections = SECTION_KEYS.map((key) => root.querySelector(`[componentkey^="${key}"]`)).filter(Boolean);
+  return [header, ...sections].filter(Boolean);
+}
+
+// Collects <button> descendants in document order, stopping at (and excluding)
+// the element's first <hr> - mirrors trimAtFirstHr's boundary without needing to
+// clone/mutate anything, since callers here need the real nodes to click.
+function buttonsBeforeFirstHr(el) {
+  const buttons = [];
+  let hitHr = false;
+  const walk = (node) => {
+    [...node.children].some((child) => {
+      if (child.tagName === 'HR') {
+        hitHr = true;
+        return true;
+      }
+      if (child.tagName === 'BUTTON') buttons.push(child);
+      walk(child);
+      return hitHr;
+    });
+  };
+  walk(el);
+  return buttons;
+}
+
 function expandTruncated(root) {
-  const toggles = [...root.querySelectorAll('button')].filter((b) => TRUNCATION_TOGGLE.test(b.textContent.trim()));
+  const toggles = truncationScope(root)
+    .flatMap(buttonsBeforeFirstHr)
+    .filter((b) => TRUNCATION_TOGGLE.test(b.textContent.trim()));
   toggles.forEach((b) => b.click());
   return toggles.length;
 }

--- a/tests/linkedin.copy-to-markdown.test.js
+++ b/tests/linkedin.copy-to-markdown.test.js
@@ -186,24 +186,27 @@ test('collectSections — returns an empty array when no slots are present', () 
   assert.deepEqual([...collectSections(root)], []);
 });
 
-test('expandTruncated — clicks every truncation toggle in the fixture', () => {
+test('expandTruncated — clicks only the toggle inside an allow-listed section', () => {
+  // The fixture also has a "… more" button under JobDetails_PremiumCompanyInsights_,
+  // which is not in SECTION_KEYS - it must be left alone.
   const root = findRoot(loadFixtureDocument());
   const clicked = [];
   root.querySelectorAll('button').forEach((b) => {
     b.addEventListener('click', () => clicked.push(b.textContent.trim()));
   });
-  assert.equal(expandTruncated(root), 2);
-  assert.equal(clicked.length, 2);
-  clicked.forEach((label) => assert.match(label, /more/i));
+  assert.equal(expandTruncated(root), 1);
+  assert.deepEqual(clicked, ['… more']);
 });
 
 test('expandTruncated — ignores buttons that merely contain the word more', () => {
   const doc = new JSDOM(`
     <main>
-      <button>More jobs</button>
-      <button>Show more results</button>
-      <button>… more</button>
-      <button>See more</button>
+      <div componentkey="JobDetails_AboutTheJob_1">
+        <button>More jobs</button>
+        <button>Show more results</button>
+        <button>… more</button>
+        <button>See more</button>
+      </div>
     </main>
   `).window.document;
   const root = doc.querySelector('main');
@@ -218,6 +221,36 @@ test('expandTruncated — ignores buttons that merely contain the word more', ()
 test('expandTruncated — returns 0 when there is nothing to expand', () => {
   const root = new JSDOM('<main><p>text</p></main>').window.document.querySelector('main');
   assert.equal(expandTruncated(root), 0);
+});
+
+test('expandTruncated — never clicks a toggle nested inside an anchor past the <hr>', () => {
+  // Mirrors LinkedIn's real "Trending employee content" carousel: an allow-listed
+  // section (AboutTheCompany) contains real content, then an <hr>, then unrelated
+  // feed posts whose "… more" toggle sits inside an <a> wrapping the whole post.
+  // Clicking that button would bubble the click into the anchor and navigate away.
+  const doc = new JSDOM(`
+    <main>
+      <div componentkey="JobDetails_AboutTheCompany_1">
+        <p>Real company blurb <button>… more</button></p>
+        <hr>
+        <a href="https://www.linkedin.com/feed/update/urn:li:activity:123/">
+          <p>Unrelated feed post <button>… more</button></p>
+        </a>
+      </div>
+    </main>
+  `).window.document;
+  const root = doc.querySelector('main');
+  const clicked = [];
+  let navigated = false;
+  doc.querySelector('a').addEventListener('click', () => {
+    navigated = true;
+  });
+  root.querySelectorAll('button').forEach((b) => {
+    b.addEventListener('click', () => clicked.push(b.closest('a') ? 'in-anchor' : 'real'));
+  });
+  assert.equal(expandTruncated(root), 1);
+  assert.deepEqual(clicked, ['real']);
+  assert.equal(navigated, false);
 });
 
 test('waitForJobContent — resolves true immediately when content is already present', async () => {

--- a/usercss/AGENTS.md
+++ b/usercss/AGENTS.md
@@ -33,6 +33,8 @@ Every file starts with a metadata block, then one or more `@-moz-document` rules
 | `@description` | Short summary |
 | `@var` | Declares a user-configurable variable (see below) |
 
+Bump `@version` (semver) whenever a style's rules change — Stylus tracks updates by that field, so a shipped change without a bump won't be picked up by installed users.
+
 ### `@var` Declarations
 
 Variables let users tune values through the extension UI without editing raw CSS. The extension injects them as CSS custom properties (e.g. `--font-size`) that you reference with `var()`.

--- a/usercss/CLAUDE.md
+++ b/usercss/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
`expandTruncated` clicked every "…more" toggle anywhere in the whole
primary-content root, not just the header/sections the script actually
extracts. On real job postings, `AboutTheCompany`'s "Trending employee
content" carousel sits past its own `<hr>` inside that same allow-listed
section, and each carousel post's toggle button is nested inside an `<a>`
wrapping the whole post — clicking it bubbles into that anchor and
navigates the page away from the job posting.

Scope expansion to the header block plus allow-listed `SECTION_KEYS`
elements, each bounded at its first `<hr>` (mirroring `trimAtFirstHr`'s
existing truncation boundary), so only toggles inside content that
survives into the output ever get clicked.

Also adds a `CLAUDE.md` next to each directory's `AGENTS.md` (`@AGENTS.md`
import) so Claude Code picks up those conventions automatically, and
documents the existing implicit rule that `@version` should bump whenever
a script/style's behavior changes.

## Commits
- `test`: regression coverage for `expandTruncated` scoping, including the
  real-world anchor-nested-toggle-past-`<hr>` case
- `fix`: scope `expandTruncated` to allow-listed content only
- `docs`: per-directory `CLAUDE.md` shims and version-bump convention